### PR TITLE
Cache Downloaded Mods, Switch to gitmoji, and Improve Build Workflow Triggers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,8 +69,11 @@ jobs:
         id: cache-save-custom
         uses: actions/cache/save@v4
         with:
-          path: cache
-          key: custom-cache-${{ hashFiles('cache/**/index.json') }} # only need to save a new version of the cache if something updated
+          path: |
+            cache
+            src/papyrus/scraping/download/BSArch.exe
+            data/*/*/download
+          key: custom-cache-${{ hashFiles('cache/**/index.json', 'src/papyrus/scraping/download/BSArch.exe', 'data/*/*/download/.nexusFileId') }} # only need to save a new version of the cache if something updated
 
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,16 @@ on:
   push:
     branches:
       - production
-  schedule: # every sunday at midnight (so we always have Function of the Day up to date and our wiki data is reasonably fresh)
+    paths:
+      - .github/workflows/build.yaml
+      - src/**
+      - data/**
+      - public/**
+      - pnpm-lock.yaml
+      - '*.js' # only applied to top-level files, don't worry
+      - '*.ts'
+      - '*.json'
+  schedule: # every Sunday at midnight (so we always have Function of the Day up to date and our wiki data is reasonably fresh)
     - cron: '0 0 * * 0'
 
 jobs:

--- a/.vscode/cspell/names.cspell
+++ b/.vscode/cspell/names.cspell
@@ -31,6 +31,7 @@ estree
 fontawesome
 fortawesome
 geolite
+gitmoji
 globby
 googleplay
 gorhom

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,23 +3,21 @@
 I'm always open to any contributions you may have. If you're looking to contribute but don't know what to do, there are some important ways you can help out:
 
 ### Suggest New Scripts
-
 There are a LOT of developer-oriented Papyrus APIs and libraries out there. If you know of one that isn't listed in the Papyrus Index, check if it would qualify by reading [the Inclusion Criteria](./data/README.md#inclusion-criteria) and then [add an issue](/BellCubeDev/papyrus-index/issues/new) with the details. I'll take a look and see if it's a good fit!
 
 ### Testing & Reporting Bugs
-
 I can't humanly test every scenario. Naturally, people (like you!) are going to find bugs. If you do find one, please [report it](/BellCubeDev/papyrus-index/issues/new) with as much detail as you can. If you can reproduce it, that's amazing! If you can't reproduce it, that's okay too—report it anyway and we'll see what we can do.
 
 ### Feature Requests & User Feedback
-
 More ideas, more better! If you have a suggestion that you think might help make the Papyrus Index more useful, [add an issue](/BellCubeDev/papyrus-index/issues/new) and I'll gladly take a look!
 
 If you've found something confusing when working with the Index (or just want to say thanks), I'd love to hear from you! [Add an issue](/BellCubeDev/papyrus-index/issues/new) or [start a discussion](/BellCubeDev/papyrus-index/discussions/new) and let me know what you think!
 
 ### Direct Contributions (Styling, New Features, etc.)
-
 If you're familiar (or willing to get familiar) with the project structure and/or React and/or Next.js and/or the custom tech this project requires, you're always welcome to submit a pull request directly. I'll review it and we'll see where it goes from there! Anything is fair game, especially if you want to address [an existing issue](/BellCubeDev/papyrus-index/issues)!
 
-### Translation
+#### Git Message Style - gitmoji
+This repository makes use of gitmoji, an emoji-based commit message convention. The goal is to boil the purpose of a commit down to a single image, making it easier to quickly parse a commit's message. You can find out more about gitmoji [here](https://gitmoji.dev/).
 
+### Translation
 The Papyrus Index is not accepting localization contributions at this time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,5 +19,10 @@ If you're familiar (or willing to get familiar) with the project structure and/o
 #### Git Message Style - gitmoji
 This repository makes use of gitmoji, an emoji-based commit message convention. The goal is to boil the purpose of a commit down to a single image, making it easier to quickly parse a commit's message. You can find out more about gitmoji [here](https://gitmoji.dev/).
 
+For example:
+> 🎨 Improve formatting of search results
+> 🔍 Add dynamic descriptions to function pages
+> 🐛 Fix struct member types not displaying tooltips when hovered
+
 ### Translation
 The Papyrus Index is not accepting localization contributions at this time.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Papyrus Index
 
-[![Components made with React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)](https://reactnative.dev/)
+[![Components made with React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)](https://react.dev/)
 [![Built with Next JS](https://img.shields.io/badge/Next-black?style=for-the-badge&logo=next.js&logoColor=white)](https://nextjs.org/)
 [![Packages managed via pnpm](https://img.shields.io/badge/pnpm-%234a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220)](https://pnpm.io/)
 [![Commit Formatting dictated by gitmoji](https://img.shields.io/badge/gitmoji-%20😜%20😍-FFDD67.svg?style=for-the-badge)](https://gitmoji.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # The Papyrus Index
 
+[![Components made with React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)](https://reactnative.dev/)
+[![Built with Next JS](https://img.shields.io/badge/Next-black?style=for-the-badge&logo=next.js&logoColor=white)](https://nextjs.org/)
+[![Packages managed via pnpm](https://img.shields.io/badge/pnpm-%234a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220)](https://pnpm.io/)
+[![Commit Formatting dictated by Gitmoji](https://img.shields.io/badge/gitmoji-%20😜%20😍-FFDD67.svg?style=flat-square)](https://gitmoji.dev)
+
 The Papyrus Index is a project to provide indexing, useful searching, and documentation for all developer-oriented Papyrus functions, properties, and events&mdash;for all Papyrus-using games.
+
+Site deployed at https://papyrus.bellcube.dev/ from the [`production` branch](https://github.com/BellCubeDev/papyrus-index/tree/production)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Components made with React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)](https://reactnative.dev/)
 [![Built with Next JS](https://img.shields.io/badge/Next-black?style=for-the-badge&logo=next.js&logoColor=white)](https://nextjs.org/)
 [![Packages managed via pnpm](https://img.shields.io/badge/pnpm-%234a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220)](https://pnpm.io/)
-[![Commit Formatting dictated by Gitmoji](https://img.shields.io/badge/gitmoji-%20😜%20😍-FFDD67.svg?style=flat-square)](https://gitmoji.dev)
+[![Commit Formatting dictated by gitmoji](https://img.shields.io/badge/gitmoji-%20😜%20😍-FFDD67.svg?style=for-the-badge)](https://gitmoji.dev)
 
 The Papyrus Index is a project to provide indexing, useful searching, and documentation for all developer-oriented Papyrus functions, properties, and events&mdash;for all Papyrus-using games.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nexus-data-tools",
+  "name": "papyrus-index",
   "version": "0.1.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Changelog
* Build workflow now caches downloaded mods
* Local builds will now update downloaded mods if the Nexus Mods ID in the source's `meta.yaml` file changes
* Build workflow now only triggers when significant paths are updated
* Repository should now use gitmoji for the commit style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added deployment site URL at `https://papyrus.bellcube.dev/`
	- Enhanced mod download management with file ID tracking

- **Documentation**
	- Added badges for React, Next.js, pnpm, and gitmoji
	- Updated contributing guidelines with gitmoji commit message style

- **Chores**
	- Renamed package from `nexus-data-tools` to `papyrus-index`
	- Updated GitHub workflow triggers and caching mechanisms
	- Added `gitmoji` to spell-checking dictionary
<!-- end of auto-generated comment: release notes by coderabbit.ai -->