### PR TITLE
🐛 Parser - Fix slash at the end of extracted multi-line comments

### DIFF
--- a/src/papyrus/parsing/parse-script.ts
+++ b/src/papyrus/parsing/parse-script.ts
@@ -327,9 +327,8 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
 
         const newIndexBeforeAddition = this.sourceCodeCased.indexOf('/;', oldIndex + 1);
         if (newIndexBeforeAddition === -1) throw new PapyrusParserError('Multi-line comment never ended!', oldIndex, this.document);
+        this.currentCommentRaw = this.sourceCodeCased.slice(oldIndex, newIndexBeforeAddition);
         this.index = newIndexBeforeAddition + 1;
-
-        this.currentCommentRaw = this.sourceCodeCased.slice(oldIndex, this.index);
     }
 
     /**


### PR DESCRIPTION
A multi-line comment written as `";/ banana /;"` would previously have be extracted as `"banana /"`, which is not the intended result. That final slash is erroneous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for extracting multi-line text segments. This internal improvement enhances clarity and maintainability while keeping all visible functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->