### PR TITLE
♻️ Refactor manual game checks into abstraction `PapyrusFeature`/`isPapyrusFeatureSupported`

### DIFF
--- a/src/app/[game]/script/[scriptNameNoExt]/page.tsx
+++ b/src/app/[game]/script/[scriptNameNoExt]/page.tsx
@@ -16,6 +16,7 @@ import { JsonLDGraph } from "../../../components/JsonLDGraph";
 import { prepareUrlParts } from "../../../../utils/prepareUrlParts";
 import type { APIReference, BreadcrumbList, ComputerLanguage } from "schema-dts";
 import { _ } from "ajv";
+import { isPapyrusFeatureSupported, PapyrusFeature } from "@/papyrus/feature-support";
 
 export function generateStaticParams(): ScriptRouteParams[] {
     const params: [complexity: number, paramObj: ScriptRouteParams][] = [];
@@ -69,10 +70,12 @@ export default async function ScriptPage({params}: {readonly params: Promise<Scr
                 <summary>Inheritance Tree</summary>
                 <InheritanceDisplay game={game} data={scriptBySources[AllSourcesCombined].extendedBy} />
             </details>
-            <details suppressHydrationWarning>
-                <summary>Structs</summary>
-                <div className={styles.structs}></div> { /* TODO: Add structs to the script page */ }
-            </details>
+            {isPapyrusFeatureSupported(PapyrusFeature.Structs, game) ?
+                <details suppressHydrationWarning>
+                    <summary>Structs</summary>
+                    <div className={styles.structs}></div> { /* TODO: Add structs to the script page */ }
+                </details>
+            : null}
             <details suppressHydrationWarning>
                 {/* Include property groups here too! */}
                 <summary>Properties</summary>

--- a/src/app/[game]/search-data.json/route.ts
+++ b/src/app/[game]/search-data.json/route.ts
@@ -13,6 +13,7 @@ import { getMediaWikiFunctionData } from "../../../wiki-data-extraction/ck-wiki/
 import { getBestStringVariant } from "../../../utils/getBestName";
 import { AllSourcesCombined } from "../../../papyrus/data-structures/indexing/game";
 import { getGitHubWikiFunctionData } from "../../components/papyrus/function/signature/getGitHubWikiFunctionDescription";
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 
 const PapyrusGamesCaseMapped = new Map<string, PapyrusGame>(Object.values(PapyrusGame).map(game => [game.toLowerCase(), game]));
 
@@ -96,7 +97,7 @@ async function getExtraEntityDataForProperty(prop: PapyrusScriptPropertyIndexedA
         githubWikiData: null,
     }];
 }
-async function getExtraEntityDataForStruct(struct: PapyrusScriptStructIndexedAggregate<Exclude<PapyrusGame, PapyrusGame.SkyrimSE>>): Promise<[number, SingleExtraEntityDataRecord[SearchIndexEntityType.Struct]]> {
+async function getExtraEntityDataForStruct(struct: PapyrusScriptStructIndexedAggregate<PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>): Promise<[number, SingleExtraEntityDataRecord[SearchIndexEntityType.Struct]]> {
     // TODO: Implement getExtraEntityDataForStruct()
     return [struct.$entityId, {
         ckWikiData: null,

--- a/src/app/components/papyrus/struct/PapyrusScriptReferenceTooltip.tsx
+++ b/src/app/components/papyrus/struct/PapyrusScriptReferenceTooltip.tsx
@@ -1,9 +1,9 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptStructIndexed } from "../../../../papyrus/data-structures/indexing/struct";
 import { UnknownPapyrusScriptStruct } from "../../../../papyrus/data-structures/indexing/type";
-import type { PapyrusGame } from "../../../../papyrus/data-structures/pure/game";
 import styles from './PapyrusStructReference.module.scss';
 
-export function PapyrusStructReferenceTooltip<TGame extends PapyrusGame>(propsObj: {readonly struct: PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>, readonly possibleStructs?: undefined} | {readonly possibleStructs: typeof UnknownPapyrusScriptStruct | Record<Lowercase<string>, PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>, readonly struct?: undefined}) {
+export function PapyrusStructReferenceTooltip(propsObj: {readonly struct: PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>, readonly possibleStructs?: undefined} | {readonly possibleStructs: typeof UnknownPapyrusScriptStruct | Record<Lowercase<string>, PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>>, readonly struct?: undefined}) {
     const {struct, possibleStructs} = propsObj;
     if (struct) {
         return <div className={styles.tooltip}>

--- a/src/app/components/papyrus/struct/PapyrusStructReference.tsx
+++ b/src/app/components/papyrus/struct/PapyrusStructReference.tsx
@@ -1,15 +1,15 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptStructIndexed } from "../../../../papyrus/data-structures/indexing/struct";
 import { UnknownPapyrusScriptStruct } from "../../../../papyrus/data-structures/indexing/type";
-import type { PapyrusGame } from "../../../../papyrus/data-structures/pure/game";
 import { UnreachableError } from "../../../../UnreachableError";
 import { getBestString } from "../../../../utils/getBestName";
 import { Tooltip } from "../../tooltip/Tooltip";
 import { PapyrusStructReferenceTooltip } from "./PapyrusScriptReferenceTooltip";
 import styles from './PapyrusStructReference.module.scss';
 
-export function PapyrusStructReference<TGame extends PapyrusGame>(propsObj: {inTooltip?: boolean|undefined} & (
-    | {readonly struct: PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>, readonly possibleStructs?: undefined}
-    | {readonly possibleStructs: typeof UnknownPapyrusScriptStruct | Record<Lowercase<string>, PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>, readonly struct?: undefined})) {
+export function PapyrusStructReference(propsObj: {inTooltip?: boolean|undefined} & (
+    | {readonly struct: PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>, readonly possibleStructs?: undefined}
+    | {readonly possibleStructs: typeof UnknownPapyrusScriptStruct | Record<Lowercase<string>, PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>>, readonly struct?: undefined})) {
     const {inTooltip, struct, possibleStructs} = propsObj;
     if (struct) {
         if (inTooltip) return <span className={styles.reference}>{struct.name}</span>;

--- a/src/app/search/Entity.ts
+++ b/src/app/search/Entity.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptEventOrBaseFunctionIndexedAggregate, PapyrusScriptFunctionIndexedAggregate } from "../../papyrus/data-structures/indexing/function";
 import type { PapyrusScriptPropertyIndexedAggregate } from "../../papyrus/data-structures/indexing/property";
 import type { PapyrusScriptIndexedAggregate } from "../../papyrus/data-structures/indexing/script";
@@ -61,7 +62,7 @@ export interface SearchEntityEvent<TGame extends PapyrusGame> extends SearchEnti
 export interface SearchEntityProperty<TGame extends PapyrusGame> extends SearchEntityPropertyAdditions, PapyrusScriptPropertyIndexedAggregate<TGame> {
 }
 
-export interface SearchEntityStruct<TGame extends PapyrusGame> extends SearchEntityStructAdditions, PapyrusScriptStructIndexedAggregate<Exclude<TGame, PapyrusGame.SkyrimSE>> {
+export interface SearchEntityStruct<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> extends SearchEntityStructAdditions, PapyrusScriptStructIndexedAggregate<TGame> {
 }
 
 export type SearchEntityBaseTypeMapping<TGame extends PapyrusGame> = {
@@ -69,13 +70,13 @@ export type SearchEntityBaseTypeMapping<TGame extends PapyrusGame> = {
     readonly [SearchIndexEntityType.Function]: PapyrusScriptFunctionIndexedAggregate<TGame>;
     readonly [SearchIndexEntityType.Event]: PapyrusScriptEventOrBaseFunctionIndexedAggregate<TGame>;
     readonly [SearchIndexEntityType.Property]: PapyrusScriptPropertyIndexedAggregate<TGame>;
-    readonly [SearchIndexEntityType.Struct]: PapyrusScriptStructIndexedAggregate<Exclude<TGame, PapyrusGame.SkyrimSE>>;
+    readonly [SearchIndexEntityType.Struct]: PapyrusScriptStructIndexedAggregate<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>;
 }
 
 
 
-export type SearchIndexEntity<TGame extends PapyrusGame> = SearchEntityScript<TGame> | SearchEntityFunction<TGame> | SearchEntityEvent<TGame> | SearchEntityProperty<TGame> | SearchEntityStruct<TGame>;
-export type SearchIndexEntityKeys<TGame extends PapyrusGame> = keyof SearchEntityScript<TGame> | keyof SearchEntityFunction<TGame> | keyof SearchEntityEvent<TGame> | keyof SearchEntityProperty<TGame> | keyof SearchEntityStruct<TGame>;
+export type SearchIndexEntity<TGame extends PapyrusGame> = SearchEntityScript<TGame> | SearchEntityFunction<TGame> | SearchEntityEvent<TGame> | SearchEntityProperty<TGame> | SearchEntityStruct<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>;
+export type SearchIndexEntityKeys<TGame extends PapyrusGame> = keyof SearchEntityScript<TGame> | keyof SearchEntityFunction<TGame> | keyof SearchEntityEvent<TGame> | keyof SearchEntityProperty<TGame> | keyof SearchEntityStruct<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>;
 
 
 
@@ -84,7 +85,7 @@ export type SearchIndexEntitiesRecordRawType<TGame extends PapyrusGame> = {
     readonly [SearchIndexEntityType.Function]: SearchEntityFunction<TGame>,
     readonly [SearchIndexEntityType.Event]: SearchEntityEvent<TGame>,
     readonly [SearchIndexEntityType.Property]: SearchEntityProperty<TGame>,
-    readonly [SearchIndexEntityType.Struct]: SearchEntityStruct<TGame>,
+    readonly [SearchIndexEntityType.Struct]: SearchEntityStruct<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>,
 }
 
 export type AnySearchIndexEntity<TGame extends PapyrusGame> = SearchIndexEntitiesRecordRawType<TGame>[keyof SearchIndexEntitiesRecordRawType<TGame>];

--- a/src/app/search/SEARCH.worker.ts
+++ b/src/app/search/SEARCH.worker.ts
@@ -12,6 +12,7 @@ import type { SearchDataGETResponse, SingleExtraEntityDataRecord } from "../[gam
 import { SearchIndexEntityGroupRecord, SearchIndexEntityType, selectEntityGroups, type SearchIndexEntity, type SelectEntityGroups } from "./Entity";
 import { deepPrepareObject, getStringForSymbol, prepForBorderCrossing, SYMBOL_PREFIX, type DeepPreparedObject } from "./Preparation";
 import type { PapyrusSourceType } from "../../papyrus/data-structures/pure/scriptSource";
+import { isPapyrusFeatureSupported, PapyrusFeature, type PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 
 export interface WorkerMessageBase {
     type: string;
@@ -298,7 +299,7 @@ function getTypeSearchKey(typeRaw: DeepPreparedObject<PapyrusScriptTypeIndexed<b
             return typeof type.script === 'string' ? type.script === getStringForSymbol(UnknownPapyrusScript) ? type.scriptName : '' : Object.values(type.script)[0]!.namespaceName;
         }
         case PapyrusScriptTypeArchetype.Struct: {
-            const type = typeRaw as DeepPreparedObject<PapyrusScriptTypeStructIndexed<boolean, false, Exclude<PapyrusGame, PapyrusGame.SkyrimSE>>>;
+            const type = typeRaw as DeepPreparedObject<PapyrusScriptTypeStructIndexed<boolean, false, PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>>;
             return typeof type.struct === 'string' ? type.struct === getStringForSymbol(UnknownPapyrusScriptStruct) ? `${type.scriptName} ${type.structName}` : ''
                 : typeof type.script === 'string' ? type.script === getStringForSymbol(UnknownPapyrusScript) ? `${type.scriptName} ${Object.values(type.struct)[0]!.name}` : ''
                 : `${Object.values(type.script)[0]!.namespaceName} ${Object.values(type.struct)[0]!.name}`;
@@ -360,10 +361,10 @@ self.addEventListener('message', async function searchWorkerMessageHandler(e: Me
                             if (matchedKeys.find((value) => value.target === coolestSource.sourceIdentifier)) newScore *= 2;
                             if (matchedKeys.find((value) => value.target.toLowerCase() === obj.namespaceName[0]![1].target)) newScore *= 10;
 
-                            if (game === PapyrusGame.SkyrimSE) {
-                                if (obj.isHidden) newScore *= 8;
-                            } else {
+                            if (isPapyrusFeatureSupported(PapyrusFeature.NativeScriptFlag, game)) {
                                 if (obj.isNative.some(v => v[1])) newScore *= 8;
+                            } else {
+                                if (obj.isHidden) newScore *= 8;
                             }
 
                             break;

--- a/src/papyrus/data-structures/indexing/function.ts
+++ b/src/papyrus/data-structures/indexing/function.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusCompilerOptional } from "../pure/compilerOptional";
 import type { PapyrusScriptDocumentable, PapyrusScriptDocumentableOnlyByComment } from "../pure/documentable";
 import type { PapyrusGame } from "../pure/game";
@@ -30,8 +31,8 @@ type PapyrusScriptEventOrBaseFunctionIndexedAggregateBase<TGame extends PapyrusG
 type PapyrusScriptEventOrBaseFunctionIndexedAggregateSpecialKeys<TGame extends PapyrusGame> = {
     $entityId: number;
     $sources: Record<Lowercase<string>, PapyrusScriptEventOrBaseFunctionIndexed<TGame>>;
-    isBetaOnly: [Lowercase<string>[], false | (TGame extends PapyrusGame.Fallout4 | PapyrusGame.Fallout76 | PapyrusGame.Starfield ? boolean : never)][];
-    isDebugOnly: [Lowercase<string>[], false | (TGame extends PapyrusGame.Fallout4 | PapyrusGame.Fallout76 | PapyrusGame.Starfield ? boolean : never)][];
+    isBetaOnly: [Lowercase<string>[], false | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.CompilerTargets> ? boolean : never)][];
+    isDebugOnly: [Lowercase<string>[], false | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.CompilerTargets> ? boolean : never)][];
     script: PapyrusScriptIndexedAggregate<TGame>;
     game: PapyrusGameDataIndexed<TGame>;
     parameters: (PapyrusScriptFunctionParameterIndexed<TGame> & {$sources: Record<Lowercase<string>, PapyrusScriptFunctionParameterIndexed<TGame>>})[];

--- a/src/papyrus/data-structures/indexing/property.ts
+++ b/src/papyrus/data-structures/indexing/property.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptDocumentable } from "../pure/documentable";
 import type { PapyrusGame } from "../pure/game";
 import type { PapyrusGameDataIndexed } from "./game";
@@ -30,9 +31,9 @@ export interface PapyrusScriptPropertyIndexed<TGame extends PapyrusGame> extends
     // Post-Skyrim additions:
 
     /** If false, the value is stored in the player's save. If true, the value is read from the plugin */
-    constant: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? true : never) | false;
+    constant: false | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ConstPropertyFlag> ? boolean : never);
     /** Whether the CK will spit out a warning when this is property is not filled */
-    mandatory: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? true : never) | false;
+    mandatory: false | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.MandatoryPropertyFlag> ? boolean : never);
 }
 
 type PapyrusScriptPropertyIndexedAggregateBase<TGame extends PapyrusGame> = {
@@ -45,8 +46,8 @@ type PapyrusScriptPropertyIndexedAggregateBase<TGame extends PapyrusGame> = {
 type PapyrusScriptPropertyIndexedAggregateSpecialKeys<TGame extends PapyrusGame> = {
     $entityId: number;
     $sources: Record<Lowercase<string>, PapyrusScriptPropertyIndexed<TGame>>;
-    constant: [Lowercase<string>[], (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? true : never) | false][];
-    mandatory: [Lowercase<string>[], (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? true : never) | false][];
+    constant: [Lowercase<string>[], false | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ConstPropertyFlag> ? boolean : never)][];
+    mandatory: [Lowercase<string>[], false | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.MandatoryPropertyFlag> ? boolean : never)][];
     script: PapyrusScriptIndexedAggregate<TGame>;
     game: PapyrusGameDataIndexed<TGame>;
     group: PapyrusScriptPropertyGroupIndexedAggregate<TGame>;

--- a/src/papyrus/data-structures/indexing/propertyGroup.ts
+++ b/src/papyrus/data-structures/indexing/propertyGroup.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptDocumentable } from "../pure/documentable";
 import type { PapyrusGame } from "../pure/game";
 import type { PapyrusCollapsedSpecifier } from "../pure/propertyGroup";
@@ -7,7 +8,7 @@ import type { PapyrusScriptPropertyIndexed, PapyrusScriptPropertyIndexedAggregat
 import type { PapyrusScriptIndexed, PapyrusScriptIndexedAggregate } from "./script";
 
 export interface PapyrusScriptPropertyGroupIndexed<TGame extends PapyrusGame> extends PapyrusScriptDocumentable {
-    collapsed: PapyrusCollapsedSpecifier.Never | (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? PapyrusCollapsedSpecifier : never);
+    collapsed: PapyrusCollapsedSpecifier.Never | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.PropertyGroups> ? PapyrusCollapsedSpecifier : never);
     name: string;
     properties: Record<Lowercase<string>, PapyrusScriptPropertyIndexed<TGame>>;
     /** The script this property group originates from */
@@ -26,7 +27,7 @@ type PapyrusScriptPropertyGroupIndexedAggregateBase<TGame extends PapyrusGame> =
 type PapyrusScriptPropertyGroupIndexedAggregateSpecialKeys<TGame extends PapyrusGame> = {
     $entityId: number;
     $sources: Record<Lowercase<string>, PapyrusScriptPropertyGroupIndexed<TGame>>;
-    collapsed: [Lowercase<string>[], PapyrusCollapsedSpecifier.Never | (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? PapyrusCollapsedSpecifier : never)][];
+    collapsed: [Lowercase<string>[], PapyrusCollapsedSpecifier.Never | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.PropertyGroups> ? PapyrusCollapsedSpecifier : never)][];
     properties: Record<Lowercase<string>, PapyrusScriptPropertyIndexedAggregate<TGame>>;
     script: PapyrusScriptIndexedAggregate<TGame>;
     game: PapyrusGameDataIndexed<TGame>;

--- a/src/papyrus/data-structures/indexing/script.ts
+++ b/src/papyrus/data-structures/indexing/script.ts
@@ -7,6 +7,7 @@ import type { UnknownPapyrusScript } from "./type";
 import type { PapyrusScriptOnlyProps } from "../pure/script";
 import type { PapyrusGameDataIndexed } from "./game";
 import type { PapyrusScriptSourceIndexed } from "./scriptSource";
+import type { PapyrusFeature, PapyrusFeatureSupportedGames, PapyrusFeatureUnsupportedGames } from "@/papyrus/feature-support";
 
 export interface PapyrusScriptIndexed<TGame extends PapyrusGame> extends PapyrusScriptOnlyProps<TGame> {
     nameWithoutNamespace: string;
@@ -33,16 +34,16 @@ export interface PapyrusScriptIndexed<TGame extends PapyrusGame> extends Papyrus
     /** Properties, stored by group then name. The default group is "" */
     propertyGroups: Record<Lowercase<string>, PapyrusScriptPropertyGroupIndexed<TGame>>;
 
-    isConst: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false;
+    isConst: (TGame extends  PapyrusFeatureSupportedGames<PapyrusFeature.ConstScriptFlag> ? boolean : never) | false;
 
-    isNative: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never);
+    isNative: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.NativeScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.NativeScriptFlag> ? null : never);
 
-    default: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never);
+    default: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.DefaultScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.DefaultScriptFlag> ? null : never);
 
-    structs: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Record<Lowercase<string>, PapyrusScriptStructIndexed<TGame>> : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never);
+    structs: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs> ? Record<Lowercase<string>, PapyrusScriptStructIndexed<TGame>> : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.Structs> ? null : never);
 
     /** The namespace of the script, if it has one. Will never be an empty string. */
-    namespace: null | (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Exclude<string, ''> : never);
+    namespace: null | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ScriptNamespaces> ? string : never);
 
     /** Scripts this script imports (functions like a combination of `export * from './SCRIPT.js'` and importing everything into the global namespace at the same time) */
     imports: (PapyrusPossibleScripts<TGame> | typeof UnknownPapyrusScript)[];
@@ -66,20 +67,20 @@ type PapyrusScriptIndexedAggregateSpecialKeys<TGame extends PapyrusGame> = {
     game: PapyrusGameDataIndexed<TGame>;
 
     $sources: Record<Lowercase<string>, PapyrusScriptIndexed<TGame>>;
-    isConst: [Lowercase<string>[], (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false][];
-    isNative: [Lowercase<string>[], (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never)][];
-    default: [Lowercase<string>[], (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never)][];
-    namespace: [Lowercase<string>[], null | (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Exclude<string, ''> : never)][];
+    isConst: [Lowercase<string>[], (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ConstScriptFlag> ? boolean : never) | false][];
+    isNative: [Lowercase<string>[], (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.NativeScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.NativeScriptFlag> ? null : never)][];
+    default: [Lowercase<string>[], (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.DefaultScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.DefaultScriptFlag> ? null : never)][];
+    namespace: [Lowercase<string>[], null | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ScriptNamespaces> ? string : never)][];
 
     /* If true, this object and all uses of it will be compiled out in non-debug builds */
-    isDebugOnly: [Lowercase<string>[], (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false][];
+    isDebugOnly: [Lowercase<string>[], (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.CompilerTargets> ? boolean : never) | false][];
     /* If true, this object and all uses of it will be compiled out in non-debug non-beta builds */
-    isBetaOnly: [Lowercase<string>[], (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false][];
+    isBetaOnly: [Lowercase<string>[], (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.CompilerTargets> ? boolean : never) | false][];
 
     functions: Record<Lowercase<string>, PapyrusScriptFunctionIndexedAggregate<TGame>>;
     events: Record<Lowercase<string>, PapyrusScriptEventOrBaseFunctionIndexedAggregate<TGame>>;
     propertyGroups: Record<Lowercase<string>, PapyrusScriptPropertyGroupIndexedAggregate<TGame>>;
-    structs: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Record<Lowercase<string>, PapyrusScriptStructIndexedAggregate<TGame>> : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never);
+    structs: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs> ? Record<Lowercase<string>, PapyrusScriptStructIndexedAggregate<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>> : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.Structs> ? null : never);
 } & Pick<PapyrusScriptIndexed<TGame>, 'extendedBy'>
 
 export type PapyrusScriptIndexedAggregate<TGame extends PapyrusGame> = PapyrusScriptIndexedAggregateSpecialKeys<TGame> & Omit<PapyrusScriptIndexedAggregateBase<TGame>, 'source'|keyof PapyrusScriptIndexedAggregateSpecialKeys<TGame>>;

--- a/src/papyrus/data-structures/indexing/struct.ts
+++ b/src/papyrus/data-structures/indexing/struct.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptDocumentable } from "../pure/documentable";
-import type { PapyrusGame } from "../pure/game";
 import type { PapyrusGameDataIndexed } from "./game";
 import type { PapyrusScriptIndexed, PapyrusScriptIndexedAggregate } from "./script";
 import type { PapyrusScriptValueIndexed } from "./type";
 
-export interface PapyrusScriptStructIndexed<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> extends PapyrusScriptDocumentable {
+export interface PapyrusScriptStructIndexed<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> extends PapyrusScriptDocumentable {
     name: string;
     members: Record<Lowercase<string>, PapyrusScriptStructMemberIndexed<TGame>>;
 
@@ -15,14 +15,14 @@ export interface PapyrusScriptStructIndexed<TGame extends Exclude<PapyrusGame, P
     game: PapyrusGameDataIndexed<TGame>;
 }
 
-type PapyrusScriptStructIndexedAggregateBase<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> = {
+type PapyrusScriptStructIndexedAggregateBase<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> = {
     [K in keyof PapyrusScriptStructIndexed<TGame>]:
         NonNullable<PapyrusScriptStructIndexed<TGame>[K]> extends Record<Lowercase<string>, any>
             ? Record<Lowercase<string>, [Lowercase<string>[], PapyrusScriptStructIndexed<TGame>[K][any]][]>
             : [Lowercase<string>[], PapyrusScriptStructIndexed<TGame>[K]][];
 }
 
-type PapyrusScriptStructIndexedAggregateSpecialKeys<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> = {
+type PapyrusScriptStructIndexedAggregateSpecialKeys<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> = {
     $entityId: number;
     $sources: Record<Lowercase<string>, PapyrusScriptStructIndexed<TGame>>;
     script: PapyrusScriptIndexedAggregate<TGame>;
@@ -30,9 +30,9 @@ type PapyrusScriptStructIndexedAggregateSpecialKeys<TGame extends Exclude<Papyru
     members: Record<Lowercase<string>, PapyrusScriptStructMemberIndexedAggregate<TGame>>;
 }
 
-export type PapyrusScriptStructIndexedAggregate<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> = PapyrusScriptStructIndexedAggregateSpecialKeys<TGame> & Omit<PapyrusScriptStructIndexedAggregateBase<TGame>, keyof PapyrusScriptStructIndexedAggregateSpecialKeys<TGame>>;
+export type PapyrusScriptStructIndexedAggregate<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> = PapyrusScriptStructIndexedAggregateSpecialKeys<TGame> & Omit<PapyrusScriptStructIndexedAggregateBase<TGame>, keyof PapyrusScriptStructIndexedAggregateSpecialKeys<TGame>>;
 
-export interface PapyrusScriptStructMemberIndexed<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> extends PapyrusScriptDocumentable {
+export interface PapyrusScriptStructMemberIndexed<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> extends PapyrusScriptDocumentable {
     /** The name of this struct member */
     name: string;
     /** The type & value of this struct member */
@@ -50,14 +50,14 @@ export interface PapyrusScriptStructMemberIndexed<TGame extends Exclude<PapyrusG
     game: PapyrusGameDataIndexed<TGame>;
 }
 
-type PapyrusScriptStructMemberIndexedAggregateBase<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> = {
+type PapyrusScriptStructMemberIndexedAggregateBase<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> = {
     [K in keyof PapyrusScriptStructMemberIndexed<TGame>]:
         NonNullable<PapyrusScriptStructMemberIndexed<TGame>[K]> extends Record<Lowercase<string>, any>
             ? Record<Lowercase<string>, [Lowercase<string>[], PapyrusScriptStructMemberIndexed<TGame>[K][any]][]>
             : [Lowercase<string>[], PapyrusScriptStructMemberIndexed<TGame>[K]][];
 }
 
-type PapyrusScriptStructMemberIndexedAggregateSpecialKeys<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> = {
+type PapyrusScriptStructMemberIndexedAggregateSpecialKeys<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> = {
     $entityId: number;
     $sources: Record<Lowercase<string>, PapyrusScriptStructMemberIndexed<TGame>>;
     struct: PapyrusScriptStructIndexedAggregate<TGame>;
@@ -65,4 +65,4 @@ type PapyrusScriptStructMemberIndexedAggregateSpecialKeys<TGame extends Exclude<
     game: PapyrusGameDataIndexed<TGame>;
 }
 
-export type PapyrusScriptStructMemberIndexedAggregate<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> = PapyrusScriptStructMemberIndexedAggregateSpecialKeys<TGame> & Omit<PapyrusScriptStructMemberIndexedAggregateBase<TGame>, keyof PapyrusScriptStructMemberIndexedAggregateSpecialKeys<TGame>>;
+export type PapyrusScriptStructMemberIndexedAggregate<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> = PapyrusScriptStructMemberIndexedAggregateSpecialKeys<TGame> & Omit<PapyrusScriptStructMemberIndexedAggregateBase<TGame>, keyof PapyrusScriptStructMemberIndexedAggregateSpecialKeys<TGame>>;

--- a/src/papyrus/data-structures/indexing/type.ts
+++ b/src/papyrus/data-structures/indexing/type.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import { memoizeDevServerConst } from "../../../utils/memoizeDevServerConst";
 import type { PapyrusGame } from "../pure/game";
 import type { PapyrusScriptTypeArchetype, PapyrusScriptTypeLiteral, PapyrusScriptTypeScriptInstance, PapyrusScriptTypeStruct, PapyrusScriptTypeVar, PapyrusScriptValueBase, PapyrusScriptValueBool, PapyrusScriptValueFloat, PapyrusScriptValueInt, PapyrusScriptValueString, PapyrusScriptValueVar } from "../pure/type";
@@ -11,13 +12,13 @@ export interface PapyrusScriptTypeScriptInstanceIndexed<TIsArray extends boolean
     script: PapyrusPossibleScripts<TGame> | typeof UnknownPapyrusScript;
 }
 
-export interface PapyrusScriptTypeStructIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> extends PapyrusScriptTypeStruct<TIsArray, TIsParameter> {
+export interface PapyrusScriptTypeStructIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> extends PapyrusScriptTypeStruct<TIsArray, TIsParameter> {
     script: PapyrusPossibleScripts<TGame> | typeof UnknownPapyrusScript;
     struct: Record<Lowercase<string>, PapyrusScriptStructIndexed<TGame>> | typeof UnknownPapyrusScriptStruct;
     scriptWithStruct: Record<Lowercase<string>, readonly [PapyrusScriptIndexed<TGame>, PapyrusScriptStructIndexed<TGame>]> | typeof UnknownPapyrusScript | typeof UnknownPapyrusScriptStruct;
 }
 
-export type PapyrusScriptTypeIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends PapyrusGame> = PapyrusScriptTypeLiteral<TIsArray, TIsParameter> | PapyrusScriptTypeScriptInstanceIndexed<TIsArray, TIsParameter, TGame> | PapyrusScriptTypeStructIndexed<TIsArray, TIsParameter, Exclude<TGame, PapyrusGame.SkyrimSE>> | PapyrusScriptTypeVar<TIsArray, TIsParameter>;
+export type PapyrusScriptTypeIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends PapyrusGame> = PapyrusScriptTypeLiteral<TIsArray, TIsParameter> | PapyrusScriptTypeScriptInstanceIndexed<TIsArray, TIsParameter, TGame> | PapyrusScriptTypeStructIndexed<TIsArray, TIsParameter, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>> | PapyrusScriptTypeVar<TIsArray, TIsParameter>;
 
 
 export interface PapyrusScriptValueScriptInstanceIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends PapyrusGame> extends PapyrusScriptValueBase<TIsArray, TIsParameter>, PapyrusScriptTypeScriptInstanceIndexed<TIsArray, TIsParameter, TGame> {
@@ -26,10 +27,10 @@ export interface PapyrusScriptValueScriptInstanceIndexed<TIsArray extends boolea
     value: null;
 }
 
-export interface PapyrusScriptValueStructIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> extends PapyrusScriptValueBase<TIsArray, TIsParameter>, PapyrusScriptTypeStructIndexed<TIsArray, TIsParameter, TGame> {
+export interface PapyrusScriptValueStructIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> extends PapyrusScriptValueBase<TIsArray, TIsParameter>, PapyrusScriptTypeStructIndexed<TIsArray, TIsParameter, TGame> {
     type: PapyrusScriptTypeArchetype.Struct;
     /** The value of a PapyrusScriptValueStruct must be None for the purposes of this index. This is because you may not initialize structs outside of a function—nor may you reference properties. */
     value: null;
 }
 
-export type PapyrusScriptValueIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends PapyrusGame> = PapyrusScriptValueBool<TIsArray, TIsParameter> | PapyrusScriptValueInt<TIsArray, TIsParameter> | PapyrusScriptValueFloat<TIsArray, TIsParameter> | PapyrusScriptValueString<TIsArray, TIsParameter> | PapyrusScriptValueScriptInstanceIndexed<TIsArray, TIsParameter, TGame> | PapyrusScriptValueStructIndexed<TIsArray, TIsParameter, Exclude<TGame, PapyrusGame.SkyrimSE>> | PapyrusScriptValueVar<TIsArray, TIsParameter>;
+export type PapyrusScriptValueIndexed<TIsArray extends boolean, TIsParameter extends boolean, TGame extends PapyrusGame> = PapyrusScriptValueBool<TIsArray, TIsParameter> | PapyrusScriptValueInt<TIsArray, TIsParameter> | PapyrusScriptValueFloat<TIsArray, TIsParameter> | PapyrusScriptValueString<TIsArray, TIsParameter> | PapyrusScriptValueScriptInstanceIndexed<TIsArray, TIsParameter, TGame> | PapyrusScriptValueStructIndexed<TIsArray, TIsParameter, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>> | PapyrusScriptValueVar<TIsArray, TIsParameter>;

--- a/src/papyrus/data-structures/pure/compilerOptional.ts
+++ b/src/papyrus/data-structures/pure/compilerOptional.ts
@@ -1,8 +1,9 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusGame } from "./game";
 
 export interface PapyrusCompilerOptional<TGame extends PapyrusGame> {
     /** If true, this object and all uses of it will be compiled out in non-debug builds */
-    isDebugOnly: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false;
+    isDebugOnly: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.CompilerTargets> ? boolean : never) | false;
     /** If true, this object and all uses of it will be compiled out in non-debug non-beta builds */
-    isBetaOnly: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false;
+    isBetaOnly: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.CompilerTargets> ? boolean : never) | false;
 }

--- a/src/papyrus/data-structures/pure/property.ts
+++ b/src/papyrus/data-structures/pure/property.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptDocumentable } from "./documentable";
 import type { PapyrusGame } from "./game";
 import type { PapyrusScriptValue } from "./type";
@@ -19,7 +20,7 @@ export interface PapyrusScriptProperty<TGame extends PapyrusGame> extends Papyru
     // Post-Skyrim additions:
 
     /** If false, the value is stored in the player's save. If true, the value is read from the plugin */
-    constant: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? true : never) | false;
+    constant: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ConstPropertyFlag> ? true : never) | false;
     /** Whether the CK will spit out a warning when this is property is not filled */
-    mandatory: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? true : never) | false;
+    mandatory: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.MandatoryPropertyFlag> ? true : never) | false;
 }

--- a/src/papyrus/data-structures/pure/propertyGroup.ts
+++ b/src/papyrus/data-structures/pure/propertyGroup.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptDocumentable } from "./documentable";
 import type { PapyrusGame } from "./game";
 import type { PapyrusScriptProperty } from "./property";
@@ -10,7 +11,7 @@ export enum PapyrusCollapsedSpecifier {
 }
 
 export interface PapyrusScriptPropertyGroup<TGame extends PapyrusGame> extends PapyrusScriptDocumentable {
-    collapsed: PapyrusCollapsedSpecifier.Never | (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? PapyrusCollapsedSpecifier : never);
+    collapsed: PapyrusCollapsedSpecifier.Never | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.PropertyGroups> ? PapyrusCollapsedSpecifier : never);
     name: string;
     properties: Record<Lowercase<string>, PapyrusScriptProperty<TGame>>;
 }

--- a/src/papyrus/data-structures/pure/script.ts
+++ b/src/papyrus/data-structures/pure/script.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames, PapyrusFeatureUnsupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusCompilerOptional } from "./compilerOptional";
 import type { PapyrusScriptDocumentable } from "./documentable";
 import type { PapyrusScriptEventOrBaseFunction, PapyrusScriptFunction } from "./function";
@@ -61,8 +62,8 @@ export interface PapyrusScriptUnderConstruction<TGame extends PapyrusGame> exten
     isConst: boolean;
     isNative: boolean | null;
     default: boolean | null;
-    structs: Record<Lowercase<string>, PapyrusScriptStruct<Exclude<TGame, PapyrusGame.SkyrimSE>>> | null;
-    namespace: Exclude<string, ''> | null | undefined;
+    structs: Record<Lowercase<string>, PapyrusScriptStruct<PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>> | null;
+    namespace: string | null | undefined;
     imports: string[];
 }
 
@@ -74,9 +75,9 @@ export interface PapyrusScript<TGame extends PapyrusGame> extends PapyrusScriptU
     extends: string | null;
     functions: Record<Lowercase<string>, PapyrusScriptFunction<TGame>>;
     propertyGroups: Record<Lowercase<string>, PapyrusScriptPropertyGroup<TGame>>;
-    isConst: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false;
-    isNative: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never);
-    default: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never);
-    structs: (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Record<Lowercase<string>, PapyrusScriptStruct<TGame>> : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never);
-    namespace: null | (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Exclude<string, ''> : never);
+    isConst: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ConstScriptFlag> ? boolean : never) | false;
+    isNative: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.NativeScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.NativeScriptFlag> ? null : never);
+    default: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.DefaultScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.DefaultScriptFlag> ? null : never);
+    structs: (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs> ? Record<Lowercase<string>, PapyrusScriptStruct<TGame>> : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.Structs> ? null : never);
+    namespace: null | (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ScriptNamespaces> ? string : never);
 }

--- a/src/papyrus/data-structures/pure/struct.ts
+++ b/src/papyrus/data-structures/pure/struct.ts
@@ -1,13 +1,13 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptDocumentable } from "./documentable";
-import type { PapyrusGame } from "./game";
 import type { PapyrusScriptValue } from "./type";
 
-export interface PapyrusScriptStruct<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> extends PapyrusScriptDocumentable {
+export interface PapyrusScriptStruct<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> extends PapyrusScriptDocumentable {
     name: string;
     members: Record<Lowercase<string>, PapyrusScriptStructMember<TGame>>;
 }
 
-export interface PapyrusScriptStructMember<_TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> extends PapyrusScriptDocumentable {
+export interface PapyrusScriptStructMember<_TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> extends PapyrusScriptDocumentable {
     name: string;
     value: PapyrusScriptValue<false, false>;
     hidden: boolean;

--- a/src/papyrus/feature-support.ts
+++ b/src/papyrus/feature-support.ts
@@ -1,0 +1,90 @@
+import { PapyrusGame } from "@/papyrus/data-structures/pure/game";
+
+export enum PapyrusFeature {
+    /** Compiler targets includes flags such as "DebugOnly" and "BetaOnly" */
+    CompilerTargets = "compiler_targets",
+
+    Structs = "structs",
+
+    ScriptNamespaces = "script_namespaces",
+    ConstScriptFlag = "const_script_flag",
+    DefaultScriptFlag = "default_script_flag",
+    NativeScriptFlag = "native_script_flag",
+
+    PropertyGroups = "property_groups",
+    ConstPropertyFlag = "const_property_flag",
+    MandatoryPropertyFlag = "mandatory_property_flag",
+}
+
+export type PapyrusFeatureSupport = Record<PapyrusGame, boolean>;
+
+export const PapyrusFeatureSupport = {
+    [PapyrusFeature.CompilerTargets]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+
+    [PapyrusFeature.Structs]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+
+    [PapyrusFeature.ScriptNamespaces]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+    [PapyrusFeature.ConstScriptFlag]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+    [PapyrusFeature.DefaultScriptFlag]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+    [PapyrusFeature.NativeScriptFlag]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+
+    [PapyrusFeature.PropertyGroups]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+    [PapyrusFeature.ConstPropertyFlag]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+    [PapyrusFeature.MandatoryPropertyFlag]: {
+        [PapyrusGame.SkyrimSE]: false,
+        [PapyrusGame.Fallout4]: true,
+        [PapyrusGame.Fallout76]: true,
+        [PapyrusGame.Starfield]: true,
+    },
+} as const satisfies Record<PapyrusFeature, PapyrusFeatureSupport>;
+
+export type PapyrusFeatureSupported<TFeature extends PapyrusFeature, TGame extends PapyrusGame> = typeof PapyrusFeatureSupport[TFeature][TGame];
+type PapyrusFeatureSupportedGamesBase<TFeature extends PapyrusFeature> = {
+    [TGameIter in PapyrusGame]: PapyrusFeatureSupported<TFeature, TGameIter> extends true ? TGameIter : never
+}[PapyrusGame];
+export type PapyrusFeatureSupportedGames<TFeature extends PapyrusFeature, TGame extends PapyrusGame = PapyrusGame> = Extract<TGame, PapyrusFeatureSupportedGamesBase<TFeature>>;
+export type PapyrusFeatureUnsupportedGames<TFeature extends PapyrusFeature, TGame extends PapyrusGame = PapyrusGame> = Exclude<TGame, PapyrusFeatureSupportedGames<TFeature, TGame>>;
+
+export function isPapyrusFeatureSupported<TFeature extends PapyrusFeature, TGame extends PapyrusGame>(feature: TFeature, game: TGame): game is PapyrusFeatureSupportedGames<TFeature, TGame> {
+    return PapyrusFeatureSupport[feature][game];
+}

--- a/src/papyrus/indexing/aggregation/aggregateEventOrBaseFunction.ts
+++ b/src/papyrus/indexing/aggregation/aggregateEventOrBaseFunction.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import { UnreachableError } from "../../../UnreachableError";
 import type { PapyrusScriptEventOrBaseFunctionIndexed, PapyrusScriptEventOrBaseFunctionIndexedAggregate, PapyrusScriptFunctionParameterIndexed } from "../../data-structures/indexing/function";
 import { type PapyrusScriptTypeScriptInstanceIndexed, type PapyrusScriptTypeStructIndexed } from "../../data-structures/indexing/type";
@@ -36,7 +37,7 @@ export function aggregateEventOrBaseFunction<TGame extends PapyrusGame>(
                     case PapyrusTypeMergeFailureReason.ScriptMismatch:
                         throw new Error(`Parameter ${i} of Papyrus function ${value.script.namespaceName}${value.name}() has conflicting script names: ${(newParameter.value as PapyrusScriptTypeScriptInstanceIndexed<boolean, true, TGame>).scriptName} (from source ${source}) and ${(existingParameter.value as PapyrusScriptTypeScriptInstanceIndexed<boolean, true, TGame>).scriptName} (from sources ${Object.keys(existingParameter.$sources).join(', ')})`);
                     case PapyrusTypeMergeFailureReason.StructMismatch:
-                        throw new Error(`Parameter ${i} of Papyrus function ${value.script.namespaceName}${value.name}() has conflicting struct names: ${(newParameter.value as PapyrusScriptTypeStructIndexed<boolean, true, Exclude<TGame, PapyrusGame.SkyrimSE>>).structName} (from source ${source}) and ${(existingParameter.value as PapyrusScriptTypeStructIndexed<boolean, true, Exclude<TGame, PapyrusGame.SkyrimSE>>).structName} (from sources ${Object.keys(existingParameter.$sources).join(', ')})`);
+                        throw new Error(`Parameter ${i} of Papyrus function ${value.script.namespaceName}${value.name}() has conflicting struct names: ${(newParameter.value as PapyrusScriptTypeStructIndexed<boolean, true, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>).structName} (from source ${source}) and ${(existingParameter.value as PapyrusScriptTypeStructIndexed<boolean, true, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>).structName} (from sources ${Object.keys(existingParameter.$sources).join(', ')})`);
                     case PapyrusValueMergeFailureReason.DefaultValueMismatch:
                         throw new Error(`Parameter ${i} of Papyrus function ${value.script.namespaceName}${value.name}() has conflicting default values: "${newParameter.value.value}" (from source ${source}) and "${existingParameter.value.value}" (from sources ${Object.keys(existingParameter.$sources).join(', ')})`);
                     default:

--- a/src/papyrus/indexing/aggregation/aggregateFunction.ts
+++ b/src/papyrus/indexing/aggregation/aggregateFunction.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import { UnreachableError } from "../../../UnreachableError";
 import type { PapyrusScriptEventOrBaseFunctionIndexedAggregate, PapyrusScriptFunctionIndexed, PapyrusScriptFunctionIndexedAggregate, PapyrusScriptFunctionIndexedAggregateReturnType } from "../../data-structures/indexing/function";
 import type { PapyrusScriptTypeScriptInstanceIndexed, PapyrusScriptTypeStructIndexed } from "../../data-structures/indexing/type";
@@ -26,7 +27,7 @@ export function aggregateFunction<TGame extends PapyrusGame>(_name: Lowercase<st
                     case PapyrusTypeMergeFailureReason.ScriptMismatch:
                         throw new Error(`Return type of Papyrus function ${nextFunction.script.namespaceName}${nextFunction.name}() has conflicting script names: ${(nextFunction.returnType as PapyrusScriptTypeScriptInstanceIndexed<boolean, true, TGame>).scriptName} (from source ${source}) and ${(acc as PapyrusScriptTypeScriptInstanceIndexed<boolean, true, TGame>).scriptName} (from sources ${Object.keys(acc.$sources).join(', ')})`);
                     case PapyrusTypeMergeFailureReason.StructMismatch:
-                        throw new Error(`Return type of Papyrus function ${nextFunction.script.namespaceName}${nextFunction.name}() has conflicting struct names: ${(nextFunction.returnType as PapyrusScriptTypeStructIndexed<boolean, true, Exclude<TGame, PapyrusGame.SkyrimSE>>).structName} (from source ${source}) and ${(acc as PapyrusScriptTypeStructIndexed<boolean, true, Exclude<TGame, PapyrusGame.SkyrimSE>>).structName} (from sources ${Object.keys(acc.$sources).join(', ')})`);
+                        throw new Error(`Return type of Papyrus function ${nextFunction.script.namespaceName}${nextFunction.name}() has conflicting struct names: ${(nextFunction.returnType as PapyrusScriptTypeStructIndexed<boolean, true, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>).structName} (from source ${source}) and ${(acc as PapyrusScriptTypeStructIndexed<boolean, true, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>).structName} (from sources ${Object.keys(acc.$sources).join(', ')})`);
                     default:
                         throw new UnreachableError(merged, `Unknown Papyrus type merge failure reason "${merged}" for return type of Papyrus function ${nextFunction.script.namespaceName}${nextFunction.name}() from source ${source}`);
                 }

--- a/src/papyrus/indexing/aggregation/aggregateScript.ts
+++ b/src/papyrus/indexing/aggregation/aggregateScript.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames, PapyrusFeatureUnsupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusPossibleScripts, PapyrusScriptIndexedAggregate } from "../../data-structures/indexing/script";
 import type { PapyrusScriptStructIndexed, PapyrusScriptStructIndexedAggregate } from "../../data-structures/indexing/struct";
 import type { PapyrusGame } from "../../data-structures/pure/game";
@@ -18,8 +19,6 @@ export function aggregateScript<TGame extends PapyrusGame>(possibleScripts: Papy
     if (scriptEntries.length === 0) throw new Error('No scripts to merge!');
 
     const ref = {};
-
-    type TGameNoSkyrim = Exclude<TGame, PapyrusGame.SkyrimSE>;
 
     const aggregateScriptContext: AggregateScriptContext<TGame> = {
         ...ctx,
@@ -62,9 +61,13 @@ export function aggregateScript<TGame extends PapyrusGame>(possibleScripts: Papy
 
         // Each of these will have its record values transformed into special aggregate types, similar to how aggregateScript itself works
         functions: aggregateFunctionsRecord(scriptEntries.map(([sourceIdentifier, script]) => [sourceIdentifier, script.functions]), aggregateScriptContext),
-        structs: scriptEntries.some(v=>v[1].structs === null)
-            ? null as TGame extends PapyrusGame.SkyrimSE ? null : never
-            : aggregateStructsRecord(scriptEntries.map(([sourceIdentifier, script]) => [sourceIdentifier, script.structs as Record<Lowercase<string>, PapyrusScriptStructIndexed<TGameNoSkyrim>>]), aggregateScriptContext as AggregateScriptContext<TGameNoSkyrim>) as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Record<Lowercase<string>, PapyrusScriptStructIndexedAggregate<Exclude<TGame, PapyrusGame.SkyrimSE>>> : never) ,
+        structs: (scriptEntries.some(v=>v[1].structs === null)
+            ? null
+            : aggregateStructsRecord(
+                scriptEntries.map(([sourceIdentifier, script]) => [sourceIdentifier, script.structs as Record<Lowercase<string>, PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>>]),
+                aggregateScriptContext as AggregateScriptContext<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>
+            )
+        ) as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs> ? Record<Lowercase<string>, PapyrusScriptStructIndexedAggregate<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>> : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.Structs> ? null : never),
         events: aggregateEventsOrBaseFunctionsRecord(scriptEntries.map(([sourceIdentifier, script]) => [sourceIdentifier, script.events] as const), aggregateScriptContext),
         propertyGroups: aggregatePropertyGroupsRecord(scriptEntries.map(([sourceIdentifier, script]) => [sourceIdentifier, script.propertyGroups]), aggregateScriptContext),
     } satisfies ObjectAssignDiff<typeof ref, PapyrusScriptIndexedAggregate<TGame>>);

--- a/src/papyrus/indexing/aggregation/aggregateStruct.ts
+++ b/src/papyrus/indexing/aggregation/aggregateStruct.ts
@@ -1,15 +1,15 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptStructIndexed, PapyrusScriptStructIndexedAggregate } from "../../data-structures/indexing/struct";
-import type { PapyrusGame } from "../../data-structures/pure/game";
 import { aggregateGenericValue } from "./aggregateGenericValue";
 import type { AggregateScriptContext } from "./aggregateScript";
 import { aggregateSourceRecordWithNameRecordEntries } from "./aggregateSourceRecordWithNameRecord";
 import { aggregateStructMembersRecord } from "./aggregateStructMember";
 
-export interface AggregateStructContext<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>> extends AggregateScriptContext<TGame> {
+export interface AggregateStructContext<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>> extends AggregateScriptContext<TGame> {
     unfinishedStructAggregateRef: PapyrusScriptStructIndexedAggregate<TGame>;
 }
 
-export function aggregateStruct<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>>(
+export function aggregateStruct<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>(
     _name: Lowercase<string>,
     valuesBySource: [source: Lowercase<string>, value: PapyrusScriptStructIndexed<TGame>][],
     ctx: AggregateScriptContext<TGame>,
@@ -36,7 +36,7 @@ export function aggregateStruct<TGame extends Exclude<PapyrusGame, PapyrusGame.S
     } satisfies PapyrusScriptStructIndexedAggregate<TGame>) as PapyrusScriptStructIndexedAggregate<TGame>;
 }
 
-export function aggregateStructsRecord<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>>(
+export function aggregateStructsRecord<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>(
     recordEntries: [Lowercase<string>, Record<Lowercase<string>, PapyrusScriptStructIndexed<TGame>>][],
     ctx: AggregateScriptContext<TGame>,
 ) {

--- a/src/papyrus/indexing/aggregation/aggregateStructMember.ts
+++ b/src/papyrus/indexing/aggregation/aggregateStructMember.ts
@@ -1,6 +1,5 @@
 import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptStructMemberIndexed, PapyrusScriptStructMemberIndexedAggregate } from "../../data-structures/indexing/struct";
-import type { PapyrusGame } from "../../data-structures/pure/game";
 import { aggregateGenericValue } from "./aggregateGenericValue";
 import { aggregateSourceRecordWithNameRecordEntries } from "./aggregateSourceRecordWithNameRecord";
 import type { AggregateStructContext } from "./aggregateStruct";

--- a/src/papyrus/indexing/aggregation/aggregateStructMember.ts
+++ b/src/papyrus/indexing/aggregation/aggregateStructMember.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
 import type { PapyrusScriptStructMemberIndexed, PapyrusScriptStructMemberIndexedAggregate } from "../../data-structures/indexing/struct";
 import type { PapyrusGame } from "../../data-structures/pure/game";
 import { aggregateGenericValue } from "./aggregateGenericValue";
@@ -5,7 +6,7 @@ import { aggregateSourceRecordWithNameRecordEntries } from "./aggregateSourceRec
 import type { AggregateStructContext } from "./aggregateStruct";
 import { serializePapyrusTypeForAggregation } from "./serializePapyrusTypeForAggregation";
 
-export function aggregateStructMember<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>>(
+export function aggregateStructMember<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>(
     _name: Lowercase<string>,
     valuesBySource: [source: Lowercase<string>, value: PapyrusScriptStructMemberIndexed<TGame>][],
     ctx: AggregateStructContext<TGame>,
@@ -25,7 +26,7 @@ export function aggregateStructMember<TGame extends Exclude<PapyrusGame, Papyrus
     };
 }
 
-export function aggregateStructMembersRecord<TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE>>(
+export function aggregateStructMembersRecord<TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs>>(
     recordEntries: [Lowercase<string>, Record<Lowercase<string>, PapyrusScriptStructMemberIndexed<TGame>>][],
     ctx: AggregateStructContext<TGame>,
 ) {

--- a/src/papyrus/indexing/index-game.ts
+++ b/src/papyrus/indexing/index-game.ts
@@ -1,3 +1,4 @@
+import type { PapyrusFeature, PapyrusFeatureSupportedGames, PapyrusFeatureUnsupportedGames } from "@/papyrus/feature-support";
 import { toLowerCase } from "../../utils/toLowerCase";
 import type { PapyrusScriptEventOrBaseFunctionIndexed, PapyrusScriptFunctionIndexed, PapyrusScriptFunctionParameterIndexed } from "../data-structures/indexing/function";
 import { AllSourcesCombined, type AllSourcesCombinedObject, type PapyrusGameDataIndexed } from "../data-structures/indexing/game";
@@ -109,41 +110,41 @@ function indexScript<TGame extends PapyrusGame>(script: AnyScript<TGame>, ctx: I
         objectsThatMayNeedFutureBlacklistedSourcesRemoved,
     };
 
-    const indexedStructs = script.structs === null ? null as (TGame extends PapyrusGame.SkyrimSE ? null : never) : Object.fromEntries(Object.entries(
-        script.structs as Record<Lowercase<string>, PapyrusScriptStruct<Exclude<TGame, PapyrusGame.SkyrimSE>>> | Record<Lowercase<string>, PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>
+    const indexedStructs = script.structs === null ? null as (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.Structs> ? null : never) : Object.fromEntries(Object.entries(
+        script.structs as Record<Lowercase<string>, PapyrusScriptStruct<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>> | Record<Lowercase<string>, PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>>
     ).map(([structName, struct]) => [
         structName,
         Object.assign(struct, {
-            game: ctx.unfinishedGameRef as PapyrusGameDataIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
-            script: script as unknown as PapyrusScriptIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
+            game: ctx.unfinishedGameRef as PapyrusGameDataIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>,
+            script: script as unknown as PapyrusScriptIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>,
             members: Object.fromEntries(Object.entries(struct.members).map(([memberName, member]) => [
                 memberName,
                 Object.assign(member, {
-                    value: indexTypeValue(member.value, scriptCtx) as  PapyrusScriptValueIndexed<false, false, Exclude<TGame, PapyrusGame.SkyrimSE>>,
-                    script: script as unknown as PapyrusScriptIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
-                    struct: struct as unknown as PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
-                    game: ctx.unfinishedGameRef as PapyrusGameDataIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
-                } satisfies Partial<PapyrusScriptStructMemberIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>),
+                    value: indexTypeValue(member.value, scriptCtx) as  PapyrusScriptValueIndexed<false, false, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>,
+                    script: script as unknown as PapyrusScriptIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>,
+                    struct: struct as unknown as PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>,
+                    game: ctx.unfinishedGameRef as PapyrusGameDataIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>,
+                } satisfies Partial<PapyrusScriptStructMemberIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>>),
             ] as const)),
-        } satisfies Partial<PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>),
-    ] as const)) satisfies Record<Lowercase<string>, PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>;
+        } satisfies Partial<PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>>),
+    ] as const)) satisfies Record<Lowercase<string>, PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>>;
 
     const res: PapyrusScriptIndexed<TGame> = Object.assign(script, {
         game: ctx.unfinishedGameRef,
         source: ctx.unfinishedSourceRef,
         functions: Object.fromEntries(Object.entries(script.functions).map(([funcNameLowercase, func]) => [funcNameLowercase, Object.assign(func, {
             game: ctx.unfinishedGameRef,
-            returnType: indexType(func.returnType, scriptCtx),
-            script: script as unknown as PapyrusScriptIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
+            returnType: indexType<TGame, boolean, false>(func.returnType, scriptCtx),
+            script: script as unknown as PapyrusScriptIndexed<TGame>,
             parameters: func.parameters.map(param => Object.assign(param, {
-                value: indexTypeValue(param.value, scriptCtx),
+                value: indexTypeValue<TGame, boolean, true>(param.value, scriptCtx),
             } satisfies Partial<PapyrusScriptFunctionParameterIndexed<TGame>>)),
         } satisfies Partial<PapyrusScriptFunctionIndexed<TGame>>)])),
         events: Object.fromEntries(Object.entries(script.events).map(([eventNameLowercase, event]) => [eventNameLowercase, Object.assign(event, {
             game: ctx.unfinishedGameRef,
-            script: script as unknown as PapyrusScriptIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
+            script: script as unknown as PapyrusScriptIndexed<TGame>,
             parameters: event.parameters.map(param => Object.assign(param, {
-                value: indexTypeValue(param.value, scriptCtx),
+                value: indexTypeValue<TGame, boolean, true>(param.value, scriptCtx),
             } satisfies Partial<PapyrusScriptFunctionParameterIndexed<TGame>>)),
         } satisfies Partial<PapyrusScriptEventOrBaseFunctionIndexed<TGame>>)])),
         extends: getPossibleScriptsFinal(script.extends ? toLowerCase(script.extends) : script.extends as null|'', ctx.scriptsByNameThenSource, objectsThatMayNeedFutureBlacklistedSourcesRemoved, ()=>{res.extends = UnknownPapyrusScript}),
@@ -154,19 +155,19 @@ function indexScript<TGame extends PapyrusGame>(script: AnyScript<TGame>, ctx: I
             groupName,
             Object.assign(group, {
                 game: ctx.unfinishedGameRef,
-                script: script as unknown as PapyrusScriptIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
+                script: script as unknown as PapyrusScriptIndexed<TGame>,
                 properties: Object.fromEntries(Object.entries(group.properties).map(([propertyName, property]) => [
                     propertyName,
                     Object.assign(property, {
                         game: ctx.unfinishedGameRef,
-                        script: script as unknown as PapyrusScriptIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
-                        group: group as unknown as PapyrusScriptPropertyGroupIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>,
-                        value: indexTypeValue(property.value, scriptCtx),
+                        script: script as unknown as PapyrusScriptIndexed<TGame>,
+                        group: group as unknown as PapyrusScriptPropertyGroupIndexed<TGame>,
+                        value: indexTypeValue<TGame, boolean, false>(property.value, scriptCtx),
                     } satisfies Partial<PapyrusScriptPropertyIndexed<TGame>>),
                 ] as const)),
             } satisfies Partial<PapyrusScriptPropertyGroupIndexed<TGame>>),
         ] as const)),
-        structs: indexedStructs as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Record<Lowercase<string>, PapyrusScriptStructIndexed<TGame>> : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never),
+        structs: indexedStructs as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs> ? Record<Lowercase<string>, PapyrusScriptStructIndexed<TGame>> : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.Structs> ? null : never),
     } satisfies Partial<PapyrusScriptIndexed<TGame>>);
 
     for (const object of objectsThatMayNeedFutureBlacklistedSourcesRemoved) {
@@ -284,7 +285,7 @@ function indexType<TGame extends PapyrusGame, TIsArray extends boolean, TIsParam
         case PapyrusScriptTypeArchetype.Struct: {
             if ('struct' in type) return type;
             const scriptNameLowercase = toLowerCase(type.scriptName);
-            const foundScriptAggregateRaw = scriptsByNameThenSource[scriptNameLowercase] as Record<Lowercase<string>, PapyrusScriptIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>> | undefined;
+            const foundScriptAggregateRaw = scriptsByNameThenSource[scriptNameLowercase] as Record<Lowercase<string>, PapyrusScriptIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>> | undefined;
             if (!foundScriptAggregateRaw) {
                 return Object.assign(type, {
                     script: UnknownPapyrusScript,
@@ -301,7 +302,7 @@ function indexType<TGame extends PapyrusGame, TIsArray extends boolean, TIsParam
             });
             const finalScriptsAggregate = Object.fromEntries(applicableScripts);
             const onEmptied = ()=>{
-                const obj = (type as unknown as PapyrusScriptTypeStructIndexed<boolean, true, Exclude<TGame, PapyrusGame.SkyrimSE>>);
+                const obj = (type as unknown as PapyrusScriptTypeStructIndexed<boolean, true, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>);
                 obj.script = UnknownPapyrusScript;
                 obj.struct = UnknownPapyrusScriptStruct;
                 obj.scriptWithStruct = UnknownPapyrusScriptStruct;
@@ -316,10 +317,10 @@ function indexType<TGame extends PapyrusGame, TIsArray extends boolean, TIsParam
             }
 
 
-            const res: PapyrusScriptTypeStructIndexed<TIsArray, TIsParameter, Exclude<TGame, PapyrusGame.SkyrimSE>> = Object.assign(type, {
+            const res: PapyrusScriptTypeStructIndexed<TIsArray, TIsParameter, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>> = Object.assign(type, {
                 script: finalScriptsAggregate,
-                struct: Object.fromEntries(applicableScripts.map(([sourceIdentifier, script]) => [sourceIdentifier, (script.structs as Record<Lowercase<string>, PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>)[structNameLowercase]!] as const)),
-                scriptWithStruct: Object.fromEntries(applicableScripts.map(([sourceIdentifier, script]) => [sourceIdentifier, [script, (script.structs as Record<Lowercase<string>, PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>)[structNameLowercase]!] as const] as const)),
+                struct: Object.fromEntries(applicableScripts.map(([sourceIdentifier, script]) => [sourceIdentifier, (script.structs as Record<Lowercase<string>, PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>>)[structNameLowercase]!] as const)),
+                scriptWithStruct: Object.fromEntries(applicableScripts.map(([sourceIdentifier, script]) => [sourceIdentifier, [script, (script.structs as Record<Lowercase<string>, PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>>)[structNameLowercase]!] as const] as const)),
             } as const);
 
             ctx.objectsThatMayNeedFutureBlacklistedSourcesRemoved.add(Object.assign(res.struct, {[ON_EMPTIED]: onEmptied}));
@@ -329,12 +330,12 @@ function indexType<TGame extends PapyrusGame, TIsArray extends boolean, TIsParam
         }
         case PapyrusScriptTypeArchetype.ScriptInstanceOrStruct: {
             const thisScriptNameLowercase = toLowerCase(ctx.script.namespaceName);
-            const foundScriptAggregates = [scriptsByNameThenSource[thisScriptNameLowercase] as Record<Lowercase<string>, PapyrusScriptIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>>, ...getAllDownstreamScripts(ctx.script, ctx.scriptsByNameThenSource)];
+            const foundScriptAggregates = [scriptsByNameThenSource[thisScriptNameLowercase] as Record<Lowercase<string>, PapyrusScriptIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>>, ...getAllDownstreamScripts(ctx.script, ctx.scriptsByNameThenSource)];
 
             const ambiguousNameLowercase = toLowerCase(type.ambiguousName);
-            const scriptsWithTargetStruct: AnyScriptPossibleScripts<Exclude<TGame, PapyrusGame.SkyrimSE>>[] = Array.from(foundScriptAggregates.map((scriptAggregate) => {
+            const scriptsWithTargetStruct: AnyScriptPossibleScripts<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>[] = Array.from(foundScriptAggregates.map((scriptAggregate) => {
                 const sourcesToBlacklistIfStructFound: Lowercase<string>[] = [];
-                const filtered = Object.entries(scriptAggregate as AnyScriptPossibleScripts<Exclude<TGame, PapyrusGame.SkyrimSE>>).filter(([sourceIdentifier, script]) => {
+                const filtered = Object.entries(scriptAggregate as AnyScriptPossibleScripts<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>).filter(([sourceIdentifier, script]) => {
                     const hasStruct = script.structs?.[ambiguousNameLowercase] !== undefined;
                     if (!hasStruct) sourcesToBlacklistIfStructFound.push(sourceIdentifier);
                     return hasStruct;
@@ -346,17 +347,17 @@ function indexType<TGame extends PapyrusGame, TIsArray extends boolean, TIsParam
 
             if (scriptsWithTargetStruct.length !== 0) {
                 if (scriptsWithTargetStruct.length > 1) console.warn('Multiple scripts with struct found for ScriptInstanceOrStruct type', {type, ctx});
-                const firstScriptAggregate = {...scriptsWithTargetStruct[0]! as PapyrusPossibleScripts<Exclude<TGame, PapyrusGame.SkyrimSE>>};
+                const firstScriptAggregate = {...scriptsWithTargetStruct[0]! as PapyrusPossibleScripts<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>};
                 const res = Object.assign(type, {
                     type: PapyrusScriptTypeArchetype.Struct,
                     script: firstScriptAggregate,
                     scriptName: Object.values(firstScriptAggregate)[0]!.namespaceName,
-                    struct: Object.fromEntries(Object.entries(firstScriptAggregate).map(([sourceIdentifier, script]) => [sourceIdentifier, script.structs![ambiguousNameLowercase] as PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>] as const)),
+                    struct: Object.fromEntries(Object.entries(firstScriptAggregate).map(([sourceIdentifier, script]) => [sourceIdentifier, script.structs![ambiguousNameLowercase] as PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>] as const)),
                     structName: type.ambiguousName,
-                    scriptWithStruct: Object.fromEntries(Object.entries(firstScriptAggregate).map(([sourceIdentifier, script]) => [sourceIdentifier, [script, script.structs![ambiguousNameLowercase] as PapyrusScriptStructIndexed<Exclude<TGame, PapyrusGame.SkyrimSE>>] as const] as const))
-                } as const) satisfies PapyrusScriptTypeStructIndexed<TIsArray, TIsParameter, Exclude<TGame, PapyrusGame.SkyrimSE>>;
+                    scriptWithStruct: Object.fromEntries(Object.entries(firstScriptAggregate).map(([sourceIdentifier, script]) => [sourceIdentifier, [script, script.structs![ambiguousNameLowercase] as PapyrusScriptStructIndexed<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>] as const] as const))
+                } as const) satisfies PapyrusScriptTypeStructIndexed<TIsArray, TIsParameter, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>;
                 const onEmptied = ()=>{
-                    const obj = (type as unknown as PapyrusScriptTypeStructIndexed<boolean, true, Exclude<TGame, PapyrusGame.SkyrimSE>>);
+                    const obj = (type as unknown as PapyrusScriptTypeStructIndexed<boolean, true, PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>);
                     obj.script = UnknownPapyrusScript;
                     obj.struct = UnknownPapyrusScriptStruct;
                     obj.scriptWithStruct = UnknownPapyrusScriptStruct;

--- a/src/papyrus/parsing/parse-script.ts
+++ b/src/papyrus/parsing/parse-script.ts
@@ -12,6 +12,7 @@ import type { PapyrusScriptStruct, PapyrusScriptStructMember } from '../data-str
 import { PapyrusScriptTypeArchetype, type PapyrusScriptType, type PapyrusScriptValue } from '../data-structures/pure/type';
 import { PapyrusParserError } from './PapyrusParserError';
 import type { PapyrusScriptDiscoveredDocument } from './parse-all-for-game';
+import { isPapyrusFeatureSupported, PapyrusFeature, type PapyrusFeatureSupportedGames, type PapyrusFeatureUnsupportedGames } from '@/papyrus/feature-support';
 
 /** Note that all keywords are case-insensitive. This enum's values must be lowercase. This is enforced by TypeScript in a declaration below this enum. */
 enum PapyrusKeyword {
@@ -203,9 +204,9 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
             isConst: false,
             extends: null,
             isHidden: false,
-            structs: this.game === PapyrusGame.SkyrimSE ? null : {},
-            default: this.game === PapyrusGame.SkyrimSE ? null : false,
-            isNative: this.game === PapyrusGame.SkyrimSE ? null : false,
+            structs: !isPapyrusFeatureSupported(PapyrusFeature.Structs, this.game) ? null : {},
+            default: !isPapyrusFeatureSupported(PapyrusFeature.DefaultScriptFlag, this.game) ? null : false,
+            isNative: !isPapyrusFeatureSupported(PapyrusFeature.NativeScriptFlag, this.game) ? null : false,
         };
     }
 
@@ -383,7 +384,7 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
             this.result.namespace = null;
             this.result.nameWithoutNamespace = namespaceOrScriptName;
         } else {
-            if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Script namespaces are not supported by Skyrim\'s Papyrus compiler. Expected identifier, but got ":".', tokenIndex, this.document);
+            if (!isPapyrusFeatureSupported(PapyrusFeature.ScriptNamespaces, this.game)) throw new PapyrusParserError('Script namespaces are not supported by Skyrim\'s Papyrus compiler. Expected identifier, but got ":".', tokenIndex, this.document);
             this.result.namespace = namespaceOrScriptName;
             this.result.nameWithoutNamespace = scriptNameIfHasNamespace;
         }
@@ -431,12 +432,12 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
                     this.result.default = true;
                     break;
                 case PapyrusKeyword.DebugOnly:
-                    if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Debug-only scripts are not supported by Skyrim\'s Papyrus compiler', nextTokenIndex, this.document);
-                    this.result.isDebugOnly = true as false | (TGame extends PapyrusGame.Fallout4 | PapyrusGame.Fallout76 | PapyrusGame.Starfield ? true : never);
+                    if (!isPapyrusFeatureSupported(PapyrusFeature.CompilerTargets, this.game)) throw new PapyrusParserError('Debug-only scripts are not supported by Skyrim\'s Papyrus compiler', nextTokenIndex, this.document);
+                    this.result.isDebugOnly = true as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.CompilerTargets> ? true : never)
                     break;
                 case PapyrusKeyword.BetaOnly:
-                    if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Beta-only scripts are not supported by Skyrim\'s Papyrus compiler', nextTokenIndex, this.document);
-                    this.result.isBetaOnly = true as false | (TGame extends PapyrusGame.Fallout4 | PapyrusGame.Fallout76 | PapyrusGame.Starfield ? true : never);
+                    if (!isPapyrusFeatureSupported(PapyrusFeature.CompilerTargets, this.game)) throw new PapyrusParserError('Beta-only scripts are not supported by Skyrim\'s Papyrus compiler', nextTokenIndex, this.document);
+                    this.result.isBetaOnly = true as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.CompilerTargets> ? true : never)
                     break;
                 case '{':
                     this.result.documentationString = this.parseDocumentationString(nextTokenIndex, false);
@@ -604,7 +605,7 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
         if (structNameLowercase in this.result.structs) throw new PapyrusParserError(`Struct "${structName}" already exists in this script!`, structNameIndex, this.document);
         if (PapyrusKeywords.has(structNameLowercase)) throw new PapyrusParserError(`Struct name "${structName}" is a reserved keyword!`, structNameIndex, this.document);
 
-        const members: PapyrusScriptStructMember<Exclude<TGame, PapyrusGame.SkyrimSE>>[] = [];
+        const members: PapyrusScriptStructMember<PapyrusFeatureSupportedGames<PapyrusFeature.Structs, TGame>>[] = [];
         let [nextTokenIndex, nextTokenCased] = this.getNextToken(true);
         if (nextTokenCased === EOF) throw new PapyrusParserError('Expected struct body, but got the end of the file (EOF)!', this.originalIndex, this.document);
         let nextTokenLowercase = toLowerCase(nextTokenCased);
@@ -799,7 +800,7 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
                     if (maybeDocumentationComment !== EOF) documentationComment ??= maybeDocumentationComment;
                     break;
                 } case PapyrusKeyword.Const: {
-                    if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Const properties are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
+                    if (!isPapyrusFeatureSupported(PapyrusFeature.ConstPropertyFlag, this.game)) throw new PapyrusParserError('Const properties are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
                     isConstant = true;
                     const maybeDocumentationComment = this.getCommentBeforeNextTokenOrLineBreak();
                     if (maybeDocumentationComment !== EOF) documentationComment ??= maybeDocumentationComment;
@@ -815,7 +816,7 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
                     if (maybeDocumentationComment !== EOF) documentationComment ??= maybeDocumentationComment;
                     break;
                 } case PapyrusKeyword.Mandatory: {
-                    if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Mandatory properties are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
+                    if (!isPapyrusFeatureSupported(PapyrusFeature.MandatoryPropertyFlag, this.game)) throw new PapyrusParserError('Mandatory properties are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
                     isMandatory = true;
                     const maybeDocumentationComment = this.getCommentBeforeNextTokenOrLineBreak();
                     if (maybeDocumentationComment !== EOF) documentationComment ??= maybeDocumentationComment;
@@ -1000,14 +1001,14 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
                     isNative = true;
                     break;
                 } case PapyrusKeyword.DebugOnly: {
-                    if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Debug-only functions are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
+                    if (!isPapyrusFeatureSupported(PapyrusFeature.CompilerTargets, this.game)) throw new PapyrusParserError('Debug-only functions are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
                     //console.debug('Encountered Debug-only function flag');
                     const maybeDocumentationComment = this.getCommentBeforeNextTokenOrLineBreak();
                     if (maybeDocumentationComment !== EOF) documentationComment ??= maybeDocumentationComment;
                     isDebugOnly = true;
                     break;
                 } case PapyrusKeyword.BetaOnly: {
-                    if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Beta-only functions are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
+                    if (!isPapyrusFeatureSupported(PapyrusFeature.CompilerTargets, this.game)) throw new PapyrusParserError('Beta-only functions are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
                     //console.debug('Encountered Beta-only function flag');
                     const maybeDocumentationComment = this.getCommentBeforeNextTokenOrLineBreak();
                     if (maybeDocumentationComment !== EOF) documentationComment ??= maybeDocumentationComment;
@@ -1108,11 +1109,11 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
             const tokenLowercase = toLowerCase(tokenCased);
             switch(tokenLowercase) {
                 case PapyrusKeyword.DebugOnly:
-                    if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Debug-only events are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
+                    if (!isPapyrusFeatureSupported(PapyrusFeature.CompilerTargets, this.game)) throw new PapyrusParserError('Debug-only events are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
                     isDebugOnly = true;
                     break;
                 case PapyrusKeyword.BetaOnly:
-                    if (this.game === PapyrusGame.SkyrimSE) throw new PapyrusParserError('Beta-only events are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
+                    if (!isPapyrusFeatureSupported(PapyrusFeature.CompilerTargets, this.game)) throw new PapyrusParserError('Beta-only events are not supported by Skyrim\'s Papyrus compiler', tokenIndex, this.document);
                     isBetaOnly = true;
                     break;
                 case PapyrusKeyword.Native: // so apparently Skyrim's compiler just... supports this? idk man but Better Third Person Selection uses it
@@ -1273,7 +1274,7 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
                     isArray,
                 };
             default:
-                if (this.game === PapyrusGame.SkyrimSE) {
+                if (!isPapyrusFeatureSupported(PapyrusFeature.Structs, this.game)) {
                     return {
                         type: PapyrusScriptTypeArchetype.ScriptInstance,
                         isArray,
@@ -1419,16 +1420,16 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
             isBetaOnly: this.result.isBetaOnly ?? false,
             isDebugOnly: this.result.isDebugOnly ?? false,
             isHidden: this.result.isHidden ?? false,
-            default: (this.result.default ?? null) as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never),
-            isNative: this.result.isNative as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never),
+            default: (this.result.default ?? null) as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.DefaultScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.DefaultScriptFlag> ? null : never),
+            isNative: this.result.isNative as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.NativeScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.NativeScriptFlag> ? null : never),
             isConditional: this.result.isConditional ?? false,
-            isConst: (this.result.isConst ?? false) as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false,
+            isConst: (this.result.isConst ?? false) as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ConstScriptFlag> ? boolean : never) | false,
             documentationComment: this.result.documentationComment ?? null,
             documentationString: this.result.documentationString ?? null,
             extends: this.result.extends ?? null,
             imports: this.result.imports,
             propertyGroups: this.result.propertyGroups,
-            structs: this.result.structs as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Record<Lowercase<string>, PapyrusScriptStruct<TGame>> : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never),
+            structs: this.result.structs as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs> ? Record<Lowercase<string>, PapyrusScriptStruct<TGame>> : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.Structs> ? null : never),
             events: this.result.events,
             functions: this.result.functions,
         };
@@ -1445,16 +1446,16 @@ export class PapyrusScriptParser<TGame extends PapyrusGame> {
             isBetaOnly: this.result.isBetaOnly ?? false,
             isDebugOnly: this.result.isDebugOnly ?? false,
             isHidden: this.result.isHidden ?? false,
-            default: (this.result.default ?? null) as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never),
-            isNative: this.result.isNative as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never),
+            default: (this.result.default ?? null) as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.DefaultScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.DefaultScriptFlag> ? null : never),
+            isNative: this.result.isNative as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.NativeScriptFlag> ? boolean : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.NativeScriptFlag> ? null : never),
             isConditional: this.result.isConditional ?? false,
-            isConst: (this.result.isConst ?? false) as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? boolean : never) | false,
+            isConst: (this.result.isConst ?? false) as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.ConstScriptFlag> ? boolean : never) | false,
             documentationComment: this.result.documentationComment ?? null,
             documentationString: this.result.documentationString ?? null,
             extends: this.result.extends ?? null,
             imports: this.result.imports,
             propertyGroups: this.result.propertyGroups,
-            structs: this.result.structs as (TGame extends Exclude<PapyrusGame, PapyrusGame.SkyrimSE> ? Record<Lowercase<string>, PapyrusScriptStruct<TGame>> : never) | (TGame extends PapyrusGame.SkyrimSE ? null : never),
+            structs: this.result.structs as (TGame extends PapyrusFeatureSupportedGames<PapyrusFeature.Structs> ? Record<Lowercase<string>, PapyrusScriptStruct<TGame>> : never) | (TGame extends PapyrusFeatureUnsupportedGames<PapyrusFeature.Structs> ? null : never),
             events: this.result.events,
             functions: this.result.functions,
         };

--- a/utilityTypes.ts
+++ b/utilityTypes.ts
@@ -33,8 +33,10 @@ type SimpleObjectAssign = {
 };
 
 /** A type representing the properties that must be specified to transform type TFromType into type TIntoType */
-type ObjectAssignDiff<TFromType extends {}, TIntoType extends {}> = Partial<TIntoType> & {
-    readonly [K in keyof TIntoType as K extends keyof TFromType ? TFromType[K] extends TIntoType[K] ? never : K : K]: TIntoType[K]
+type ObjectAssignDiff<TFromType extends {}, TIntoType extends {}> = {
+    readonly [K in keyof TIntoType as K extends keyof TFromType ? TFromType[K] extends TIntoType[K] ? never : K : K]: TIntoType[K];
+} & {
+    readonly [K in keyof TIntoType as K extends keyof TFromType ? TFromType[K] extends TIntoType[K] ? K : never : never]?: TIntoType[K];
 }
 
 type RecordOfPromises<T> = { [K in keyof T]: Awaitable<T[K]> };


### PR DESCRIPTION
## Purpose

Littered throughout the codebase currently are imperative, perhaps unintuitive checks, often with unclear intentions, such as `this.game === PapyrusGame.SkyrimSE` or `Exclude<PapyrusGame, PapyrusGame.SkyrimSE>`. This pull request addresses the lack of clarity, intuition, and maintainability by abstracting these checks into a centralized list of "papyrus features" where support is not present in at least one game and a record defining which games support each feature.

## Changes
### Improvement
- 🚸 Remove Structs section from unsupported-game Script pages (i.e. Skyrim)
### Refactor
- 🧑‍💻 Added new `PapyrusFeature` enum, `PapyrusFeatureSupport` record, `isPapyrusFeatureSupported(feature, game)` function, and accompanying utility types `PapyrusFeatureSupported`, `PapyrusFeatureSupportedGames`, and `PapyrusFeatureUnsupportedGames`
- ♻️ Replaced most/all manual game checks with the above abstractions, replacing imperative checks and type definitions with much more declarative ones
### Misc
- 🏷️ TYPES: Modified `ObjectAssignDiff` to no longer create noisy `(T | undefined) & T` types, which clutter logs and impede readability/debugability for more complex type resolution errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Script pages now show the Structs section only for games that support that feature.
* **Refactor**
  * Reworked feature-support system to determine game capabilities (structs, properties, compiler targets, namespaces, etc.) dynamically, improving consistency across editions and future extensibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->