### PR TITLE
🚑 ♻️ Fix Namespaced scripts critical issues

### DIFF
--- a/src/app/[game]/getGameFromParams.ts
+++ b/src/app/[game]/getGameFromParams.ts
@@ -1,12 +1,12 @@
 import { notFound } from "next/navigation";
 import type { PapyrusGame } from "../../papyrus/data-structures/pure/game";
-import { toLowerCase } from "../../utils/toLowerCase";
 import { ValidPapyrusGames } from "../../utils/ValidPapyrusGames";
+import { unprepareUrlPart } from "@/utils/prepareUrlParts";
 
 export type GameRouteParams = {readonly game: string};
 
 export function getGameFromParams({game}: GameRouteParams): {game: PapyrusGame} {
     return {
-        game: ValidPapyrusGames.get(toLowerCase(game as PapyrusGame)) ?? notFound()
+        game: ValidPapyrusGames.get(unprepareUrlPart(game)) ?? notFound()
     };
 }

--- a/src/app/[game]/page.tsx
+++ b/src/app/[game]/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { PapyrusGame } from "../../papyrus/data-structures/pure/game";
 import { AllScriptsIndexed } from "../../papyrus/indexing/index-all";
 import { getGameName } from "../../utils/getGameName";
-import { toLowerCase } from "../../utils/toLowerCase";
 import { InheritanceDisplay } from "../components/inheritance-display/InheritanceDisplay";
 import { SourceIcon } from "../components/papyrus/SourceIcon";
 import { SourceName } from "../components/papyrus/SourceName";
@@ -16,13 +15,13 @@ import { SourcePlate } from "../components/papyrus/SourcesList";
 import { JsonLDGraph } from "../components/JsonLDGraph";
 import type { BreadcrumbList, CollectionPage } from "schema-dts";
 import { AllSourcesCombined } from "../../papyrus/data-structures/indexing/game";
-import { prepareUrlParts } from "../../utils/prepareUrlParts";
+import { prepareUrlPart, prepareUrlParts } from "../../utils/prepareUrlParts";
 import { UnreachableError } from "../../UnreachableError";
 
 
 export function generateStaticParams() {
     return Object.values(PapyrusGame).map(gameCased => ({
-        game: toLowerCase(gameCased)
+        game: prepareUrlPart(gameCased)
     }));
 }
 

--- a/src/app/[game]/raw.json/route.ts
+++ b/src/app/[game]/raw.json/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { PapyrusGame } from "../../../papyrus/data-structures/pure/game";
 import { AllScripts } from "../../../papyrus/parsing/parse-or-load-all";
-import { toLowerCase } from "../../../utils/toLowerCase";
+import { prepareUrlPart } from "@/utils/prepareUrlParts";
 import { getGameFromParams } from "@/app/[game]/getGameFromParams";
 
 export async function GET(_request: NextRequest, opts : { params: Promise<{ game: string }> }) {
@@ -10,5 +10,5 @@ export async function GET(_request: NextRequest, opts : { params: Promise<{ game
 }
 
 export function generateStaticParams() {
-    return Object.values(PapyrusGame).map(game => ({ game: toLowerCase(game) }));
+    return Object.values(PapyrusGame).map(game => ({ game: prepareUrlPart(game) }));
 }

--- a/src/app/[game]/script/[scriptNameNoExt]/(children)/function/[functionName]/getGameAndScriptAndFunctionFromParams.ts
+++ b/src/app/[game]/script/[scriptNameNoExt]/(children)/function/[functionName]/getGameAndScriptAndFunctionFromParams.ts
@@ -2,14 +2,14 @@ import { notFound } from "next/navigation";
 import type { PapyrusScriptFunctionIndexedAggregate } from "../../../../../../../papyrus/data-structures/indexing/function";
 import { AllSourcesCombined } from "../../../../../../../papyrus/data-structures/indexing/game";
 import type { PapyrusGame } from "../../../../../../../papyrus/data-structures/pure/game";
-import { toLowerCase } from "../../../../../../../utils/toLowerCase";
 import { getGameAndScriptFromParams, type ScriptRouteParams } from "../../../getGameAndScriptFromParams";
+import { unprepareUrlPart } from "@/utils/prepareUrlParts";
 
 export type FunctionRouteParams = ScriptRouteParams & {readonly functionName: string};
 
 export function getGameAndScriptAndFunctionFromParams(params: FunctionRouteParams): ReturnType<typeof getGameAndScriptFromParams> & {readonly func: PapyrusScriptFunctionIndexedAggregate<PapyrusGame>} {
     const base = getGameAndScriptFromParams(params);
-    const func = base.scriptBySources[AllSourcesCombined].functions[toLowerCase(params.functionName)];
+    const func = base.scriptBySources[AllSourcesCombined].functions[unprepareUrlPart(params.functionName)];
     if (!func) return notFound();
     return {...base, func};
 }

--- a/src/app/[game]/script/[scriptNameNoExt]/(children)/function/[functionName]/page.tsx
+++ b/src/app/[game]/script/[scriptNameNoExt]/(children)/function/[functionName]/page.tsx
@@ -5,7 +5,7 @@ import type { PapyrusScriptFunctionIndexedAggregate } from "../../../../../../..
 import { AllSourcesCombined, type PapyrusGameDataIndexed } from "../../../../../../../papyrus/data-structures/indexing/game";
 import type { PapyrusGame } from "../../../../../../../papyrus/data-structures/pure/game";
 import { AllScriptsIndexed } from "../../../../../../../papyrus/indexing/index-all";
-import { prepareUrlParts } from "../../../../../../../utils/prepareUrlParts";
+import { prepareUrlPart, prepareUrlParts } from "../../../../../../../utils/prepareUrlParts";
 import { getBestStringVariant } from "../../../../../../../utils/getBestName";
 import { getGameName } from "../../../../../../../utils/getGameName";
 import { toLowerCase } from "../../../../../../../utils/toLowerCase";
@@ -31,7 +31,7 @@ export function generateStaticParams(): FunctionRouteParams[] {
     for (const [game, gameData] of Object.entries(AllScriptsIndexed)) {
         for (const [scriptNameLowercase, scriptData] of Object.entries(gameData.scripts)) {
             for (const funcName of Object.keys(scriptData[AllSourcesCombined].functions))
-                params.push({game: toLowerCase(game), scriptNameNoExt: scriptNameLowercase, functionName: funcName});
+                params.push({game: prepareUrlPart(game), scriptNameNoExt: prepareUrlPart(scriptNameLowercase), functionName: prepareUrlPart(funcName)});
         }
     }
 

--- a/src/app/[game]/script/[scriptNameNoExt]/getGameAndScriptFromParams.ts
+++ b/src/app/[game]/script/[scriptNameNoExt]/getGameAndScriptFromParams.ts
@@ -1,16 +1,16 @@
 import { notFound } from "next/navigation";
 import { AllScriptsIndexed } from "../../../../papyrus/indexing/index-all";
-import { toLowerCase } from "../../../../utils/toLowerCase";
 import { getGameFromParams, type GameRouteParams } from "../../getGameFromParams";
 import type { PapyrusScriptBySources } from "../../../../papyrus/data-structures/indexing/game";
 import type { PapyrusGame } from "../../../../papyrus/data-structures/pure/game";
+import { unprepareUrlPart } from "@/utils/prepareUrlParts";
 
 export type ScriptRouteParams = GameRouteParams & {readonly scriptNameNoExt: string};
 
 export function getGameAndScriptFromParams(params: ScriptRouteParams): ReturnType<typeof getGameFromParams> & {scriptNameLowercase: Lowercase<string>, scriptBySources: PapyrusScriptBySources<PapyrusGame>} {
     const base = getGameFromParams(params);
     const gameData = AllScriptsIndexed[base.game];
-    const scriptNameLowercase = toLowerCase(params.scriptNameNoExt);
+    const scriptNameLowercase = unprepareUrlPart(params.scriptNameNoExt);
     const scriptBySources = gameData.scripts[scriptNameLowercase];
     if (!scriptBySources) return notFound();
     return {...base, scriptNameLowercase, scriptBySources};

--- a/src/app/[game]/script/[scriptNameNoExt]/page.tsx
+++ b/src/app/[game]/script/[scriptNameNoExt]/page.tsx
@@ -13,7 +13,7 @@ import { PapyrusTypeWithValue } from "../../../components/papyrus/type/PapyrusTy
 import { toLowerCase } from "../../../../utils/toLowerCase";
 import { SourcesList, sourcesSortFn } from "../../../components/papyrus/SourcesList";
 import { JsonLDGraph } from "../../../components/JsonLDGraph";
-import { prepareUrlParts } from "../../../../utils/prepareUrlParts";
+import { prepareUrlPart, prepareUrlParts } from "../../../../utils/prepareUrlParts";
 import type { APIReference, BreadcrumbList, ComputerLanguage } from "schema-dts";
 import { _ } from "ajv";
 import { isPapyrusFeatureSupported, PapyrusFeature } from "@/papyrus/feature-support";
@@ -25,7 +25,7 @@ export function generateStaticParams(): ScriptRouteParams[] {
         for (const [scriptNameLowercase, scriptData] of Object.entries(gameData.scripts)) {
             params.push([
                 Object.keys(scriptData[AllSourcesCombined].functions).length + Object.keys(scriptData[AllSourcesCombined].propertyGroups).length + Object.keys(scriptData[AllSourcesCombined].events).length + Object.keys(scriptData[AllSourcesCombined].structs ?? {}).length,
-                {game: toLowerCase(game), scriptNameNoExt: scriptNameLowercase}
+                {game: prepareUrlPart(game), scriptNameNoExt: prepareUrlPart(scriptNameLowercase)}
             ]);
         }
     }

--- a/src/app/[game]/search-data.json/route.ts
+++ b/src/app/[game]/search-data.json/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { PapyrusGame, type PapyrusGameData } from "../../../papyrus/data-structures/pure/game";
-import { toLowerCase } from "../../../utils/toLowerCase";
 import { AllScripts } from "../../../papyrus/parsing/parse-or-load-all";
 import { SearchEntityBaseTypeMapping, SearchIndexEntitiesRecordRawType, SearchIndexEntityType } from "../../search/Entity";
 import { AllScriptsIndexed } from "../../../papyrus/indexing/index-all";
@@ -14,8 +13,7 @@ import { getBestStringVariant } from "../../../utils/getBestName";
 import { AllSourcesCombined } from "../../../papyrus/data-structures/indexing/game";
 import { getGitHubWikiFunctionData } from "../../components/papyrus/function/signature/getGitHubWikiFunctionDescription";
 import type { PapyrusFeature, PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
-
-const PapyrusGamesCaseMapped = new Map<string, PapyrusGame>(Object.values(PapyrusGame).map(game => [game.toLowerCase(), game]));
+import { prepareUrlPart } from "@/utils/prepareUrlParts";
 
 export type SingleExtraEntityDataRecord = { [TKey in keyof SearchIndexEntitiesRecordRawType<PapyrusGame>]: ObjectAssignDiff<SearchEntityBaseTypeMapping<PapyrusGame>[SearchIndexEntitiesRecordRawType<PapyrusGame>[TKey]['$entityType']], Omit<SearchIndexEntitiesRecordRawType<PapyrusGame>[TKey],'$entityType'>> };
 export type SingleExtraEntityData = SingleExtraEntityDataRecord[keyof SingleExtraEntityDataRecord];
@@ -57,7 +55,7 @@ export async function GET(__request: unknown, opts : { params: Promise<{ game: s
 }
 
 export function generateStaticParams() {
-    return Object.values(PapyrusGame).map(game => ({ game: toLowerCase(game) }));
+    return Object.values(PapyrusGame).map(game => ({ game: prepareUrlPart(game) }));
 }
 
 async function getExtraEntityDataForScript(script: PapyrusScriptIndexedAggregate<PapyrusGame>): Promise<[number, SingleExtraEntityDataRecord[SearchIndexEntityType.Script]]> {

--- a/src/app/[game]/source/[source]/getGameAndSourceFromParams.ts
+++ b/src/app/[game]/source/[source]/getGameAndSourceFromParams.ts
@@ -2,15 +2,15 @@ import { notFound } from "next/navigation";
 import type { PapyrusScriptSourceIndexed } from "../../../../papyrus/data-structures/indexing/scriptSource";
 import type { PapyrusGame } from "../../../../papyrus/data-structures/pure/game";
 import { AllScriptsIndexed } from "../../../../papyrus/indexing/index-all";
-import { toLowerCase } from "../../../../utils/toLowerCase";
 import { getGameFromParams, type GameRouteParams } from "../../getGameFromParams";
+import { unprepareUrlPart } from "@/utils/prepareUrlParts";
 
 export type SourceRouteParams = GameRouteParams & {readonly source: string};
 
 export function getGameAndSourceFromParams(params: SourceRouteParams): ReturnType<typeof getGameFromParams> & {source: PapyrusScriptSourceIndexed<PapyrusGame>} {
     const base = getGameFromParams(params);
     const gameData = AllScriptsIndexed[base.game];
-    const sourceNameLowercase = toLowerCase(params.source);
+    const sourceNameLowercase = unprepareUrlPart(params.source);
     const sourceObj = gameData.scriptSources[sourceNameLowercase];
     if (!sourceObj) return notFound();
     return {...base, source: sourceObj};

--- a/src/app/[game]/source/[source]/page.tsx
+++ b/src/app/[game]/source/[source]/page.tsx
@@ -8,19 +8,18 @@ import { getGameName } from "../../../../utils/getGameName";
 import { SourceName } from "../../../components/papyrus/SourceName";
 import { getGameAndSourceFromParams, type SourceRouteParams } from "./getGameAndSourceFromParams";
 import { AllScripts } from "../../../../papyrus/parsing/parse-or-load-all";
-import { toLowerCase } from "../../../../utils/toLowerCase";
 import { AllScriptsIndexed } from "../../../../papyrus/indexing/index-all";
 import { PapyrusScriptReference } from "../../../components/papyrus/script/PapyrusScriptReference";
 import { wikisBySource } from "../../../../wiki-data-extraction/individual-github-wikis/wikisBySource";
 import { WikiMarkdown } from "../../../components/wiki-markdown/WikiMarkdown";
 import { JsonLDGraph } from "../../../components/JsonLDGraph";
-import { prepareUrlParts } from "../../../../utils/prepareUrlParts";
+import { prepareUrlPart, prepareUrlParts } from "../../../../utils/prepareUrlParts";
 
 export function generateStaticParams(): SourceRouteParams[] {
     const params = [];
     for (const [game, gameData] of Object.entries(AllScripts)) {
         for (const source of Object.values(gameData.scriptSources))
-            params.push({game: toLowerCase(game), source: source.sourceIdentifier});
+            params.push({game: prepareUrlPart(game), source: prepareUrlPart(source.sourceIdentifier)});
     }
     return params;
 }

--- a/src/app/components/wiki-markdown/WikiMarkdown.tsx
+++ b/src/app/components/wiki-markdown/WikiMarkdown.tsx
@@ -17,6 +17,7 @@ import { ValidPapyrusGames } from "../../../utils/ValidPapyrusGames";
 import { getWiki } from "../../../wiki-data-extraction/ck-wiki/getWiki";
 import { CodeBlock, CodeBlockLanguage } from "../code-block/CodeBlock";
 import { Link } from "../Link";
+import { unprepareUrlPart } from "@/utils/prepareUrlParts";
 
 export const AUTOMATIC_BASE_URL: unique symbol = memoizeDevServerConst('AUTOMATIC_BASE_URL', () => Symbol.for('PAPYRUS_INDEX_AUTOMATIC_BASE_URL')) as never;
 
@@ -37,7 +38,7 @@ function WikiMarkdownLink(gameData: PapyrusGameDataIndexed<PapyrusGame>, inToolt
 
         const getFallbackComponent = ()=> <Link href={url.pathname as Lowercase<string>}>{children}</Link>;
 
-        const pathnameParts = url.pathname.split('/').filter(Boolean).map((s)=> toLowerCase(decodeURI(s)));
+        const pathnameParts = url.pathname.split('/').filter(Boolean).map((s)=> unprepareUrlPart(s));
 
         const [gameLowerCase, pathnameVariable1, ...remainingPathnameParts] = pathnameParts;
 
@@ -54,7 +55,7 @@ function WikiMarkdownLink(gameData: PapyrusGameDataIndexed<PapyrusGame>, inToolt
             case 'script': {
                 const [scriptName, ...remainingScriptPathParts] = remainingPathnameParts;
                 if (!scriptName) throw new Error(`WikiMarkdownLink: 'papyrus-index:' protocol with pathname '${url.pathname}' is missing script name.`);
-                const script = gameData.scripts[toLowerCase(scriptName)];
+                const script = gameData.scripts[scriptName];
                 if (!script) {
                     if (process.env.SKIP_HIGH_LEVEL_DIAGNOSTIC_LOGS !== 'true') console.warn(`WikiMarkdownLink: 'papyrus-index:' protocol with pathname '${url.pathname}' references a script that does not exist: ${scriptName}.`);
                     appendToStepSummarySection(`\`<WikiMarkdownLink>\` component references a script that does not exist: \`${scriptName}\`.`, StepSummarySection.UnimplementedFeatures);
@@ -72,7 +73,7 @@ function WikiMarkdownLink(gameData: PapyrusGameDataIndexed<PapyrusGame>, inToolt
                 switch (pathnameVariable2) {
                     case 'function': {
                         if (!identifier) throw new Error(`WikiMarkdownLink: 'papyrus-index:' protocol with pathname '${url.pathname}' is missing function name.`);
-                        const funcAggregate = script[AllSourcesCombined].functions[toLowerCase(identifier)];
+                        const funcAggregate = script[AllSourcesCombined].functions[identifier];
                         if (!funcAggregate) {
                             if (process.env.SKIP_HIGH_LEVEL_DIAGNOSTIC_LOGS !== 'true') console.warn(`WikiMarkdownLink: 'papyrus-index:' protocol with pathname '${url.pathname}' references a function that does not exist: ${identifier}.`);
                             appendToStepSummarySection(`\`<WikiMarkdownLink>\` component references a function that does not exist: \`${identifier}\`.`, StepSummarySection.UnimplementedFeatures);
@@ -88,7 +89,7 @@ function WikiMarkdownLink(gameData: PapyrusGameDataIndexed<PapyrusGame>, inToolt
 
                     case 'event': {
                         if (!identifier) throw new Error(`WikiMarkdownLink: 'papyrus-index:' protocol with pathname '${url.pathname}' is missing event name.`);
-                        const eventAggregate = script[AllSourcesCombined].events[toLowerCase(identifier)];
+                        const eventAggregate = script[AllSourcesCombined].events[identifier];
                         if (!eventAggregate) {
                             if (process.env.SKIP_HIGH_LEVEL_DIAGNOSTIC_LOGS !== 'true') console.warn(`WikiMarkdownLink: 'papyrus-index:' protocol with pathname '${url.pathname}' references an event that does not exist: ${identifier}.`);
                             appendToStepSummarySection(`\`<WikiMarkdownLink>\` component references an event that does not exist: \`${identifier}\`.`, StepSummarySection.UnimplementedFeatures);

--- a/src/app/search/SEARCH.worker.ts
+++ b/src/app/search/SEARCH.worker.ts
@@ -13,6 +13,7 @@ import { SearchIndexEntityGroupRecord, SearchIndexEntityType, selectEntityGroups
 import { deepPrepareObject, getStringForSymbol, prepForBorderCrossing, SYMBOL_PREFIX, type DeepPreparedObject } from "./Preparation";
 import type { PapyrusSourceType } from "../../papyrus/data-structures/pure/scriptSource";
 import { isPapyrusFeatureSupported, PapyrusFeature, type PapyrusFeatureSupportedGames } from "@/papyrus/feature-support";
+import { prepareUrlParts } from "@/utils/prepareUrlParts";
 
 export interface WorkerMessageBase {
     type: string;
@@ -148,7 +149,7 @@ async function getSearchIndexOnWorkerLoad(): Promise<[DeepPreparedObject<SearchI
 
     performance.mark('startDownloadRawData');
 
-    const res = await fetch(new URL(`/${toLowerCase(game)}/search-data.json?hash=${searchIndexHash}`, self.origin), {
+    const res = await fetch(new URL(`${prepareUrlParts(game, 'search-data.json')}?hash=${searchIndexHash}`, self.origin), {
         cache: 'force-cache',
     });
     if (!res.ok) {

--- a/src/utils/prepareUrlParts.ts
+++ b/src/utils/prepareUrlParts.ts
@@ -3,8 +3,21 @@ import { toLowerCase } from "./toLowerCase";
 declare const IS_PREPARED_URL_PARTS: unique symbol; // not real
 export type PreparedURLParts = Lowercase<`/${string}/`> & {readonly [IS_PREPARED_URL_PARTS]: true};
 
+export function prepareUrlPart(part: string) {
+    part = toLowerCase(part);
+    part = part.replaceAll(':', '~'); // Next.js handles colons weirdly
+    part = encodeURIComponent(part);
+    return part;
+}
+
 export function prepareUrlParts(...parts: readonly string[]): PreparedURLParts {
     return `/${parts
-        .map(part => encodeURIComponent(toLowerCase(part)))
+        .map(prepareUrlPart)
         .join('/')}/` as PreparedURLParts;
+    }
+
+export function unprepareUrlPart(part: string) {
+    part = decodeURIComponent(part);
+    part = part.replaceAll('~', ':');
+    return toLowerCase(part); // just in case
 }


### PR DESCRIPTION
Issues with namespaced scripts:
- They would crash the site when attempting to view a tooltip involving them
- They would not receive their own pages
- I'm sure they produced invalid file paths on Windows and would cause a whole host of issues there

These have all been resolved by modifying the URL part preparation pipeline to replace ':' with '~'. To balance this, an `unprepareUrlPart` function was similarly introduced. These functions have been applied across the codebase in all appropriate places, based on existing usage of `toLowerCase`, `prepareUrlParts`, and the decoding of URL parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved URL parameter handling and encoding across the application to ensure consistent treatment of special characters in game names, scripts, functions, and source identifiers, making the platform more robust across all pages and endpoints.

* **Bug Fixes**
  * Enhanced error handling when referenced resources cannot be found, now displaying appropriate fallback content with improved user feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->